### PR TITLE
Fix demos' register use for previous installation path.

### DIFF
--- a/Demos/MUI_1_2_Full/Setup.nsi
+++ b/Demos/MUI_1_2_Full/Setup.nsi
@@ -164,8 +164,8 @@ Section "Core Files (required)" SectionCoreFiles
 			${EndSwitch}				
 		${endif}		
 			
-		Delete "$2\${UNINSTALL_FILENAME}"	; the uninstaller doesn't delete itself when not copied to the temp directory
-		RMDir "$2"		
+		Delete "$3\${UNINSTALL_FILENAME}"	; the uninstaller doesn't delete itself when not copied to the temp directory
+		RMDir "$3"		
 	${endif}	
 		
 	SetOutPath $INSTDIR

--- a/Demos/NSIS_Full/Setup.nsi
+++ b/Demos/NSIS_Full/Setup.nsi
@@ -126,8 +126,8 @@ Section "Core Files (required)" SectionCoreFiles
 			${EndSwitch}				
 		${endif}		
 			
-		Delete "$2\${UNINSTALL_FILENAME}"	; the uninstaller doesn't delete itself when not copied to the temp directory
-		RMDir "$2"		
+		Delete "$3\${UNINSTALL_FILENAME}"	; the uninstaller doesn't delete itself when not copied to the temp directory
+		RMDir "$3"		
 	${endif}	
 		
 	SetOutPath $INSTDIR

--- a/Demos/UMUI_Ex_Full/Setup.nsi
+++ b/Demos/UMUI_Ex_Full/Setup.nsi
@@ -163,8 +163,8 @@ Section "Core Files (required)" SectionCoreFiles
 			${EndSwitch}				
 		${endif}		
 			
-		Delete "$2\${UNINSTALL_FILENAME}"	; the uninstaller doesn't delete itself when not copied to the temp directory
-		RMDir "$2"		
+		Delete "$3\${UNINSTALL_FILENAME}"	; the uninstaller doesn't delete itself when not copied to the temp directory
+		RMDir "$3"		
 	${endif}	
 		
 	SetOutPath $INSTDIR


### PR DESCRIPTION
When deleting the uninstaller and the directory of a previous
installation, the register used for the path was wrong. If the user
chose a different installation path, the old directory and unistaller
would still be there.