### PR TITLE
Fix installer/uninstaller running for the wrong user

### DIFF
--- a/Demos/MUI_1_2_Full/Setup.nsi
+++ b/Demos/MUI_1_2_Full/Setup.nsi
@@ -107,14 +107,8 @@ SetCompressor /SOLID lzma
 ; Reserve files
 !insertmacro MUI_RESERVEFILE_LANGDLL
 
-; Sections
-InstType "Typical"
-InstType "Minimal"
-InstType "Full"
-
-Section "Core Files (required)" SectionCoreFiles
-	SectionIn 1 2 3 RO
-
+; Functions
+Function CheckInstallation 
 	; if there's an installed version, uninstall it first (I chose not to start the uninstaller silently, so that user sees what failed)
 	; if both per-user and per-machine versions are installed, unistall the one that matches $MultiUser.InstallMode
 	StrCpy $0 ""
@@ -143,12 +137,31 @@ Section "Core Files (required)" SectionCoreFiles
 		${else}
 			StrCpy $2 ""
 		${endif}
+	${endif}
+FunctionEnd
 
+Function RunUninstaller
+	StrCpy $0 0
+	ExecWait '$1 /SS $2 _?=$3' $0 ; $1 is quoted in registry; the _? param stops the uninstaller from copying itself to the temporary directory, which is the only way for ExecWait to work
+FunctionEnd
+
+; Sections
+InstType "Typical"
+InstType "Minimal"
+InstType "Full"
+
+Section "Core Files (required)" SectionCoreFiles
+	SectionIn 1 2 3 RO
+
+	!insertmacro UAC_AsUser_Call Function CheckInstallation ${UAC_SYNCREGISTERS}
+	${if} $0 != ""
 		HideWindow
 		ClearErrors
-		StrCpy $0 0
-		ExecWait '$1 /SS $2 _?=$3' $0 ; $1 is quoted in registry; the _? param stops the uninstaller from copying itself to the temporary directory, which is the only way for ExecWait to work
-
+		${if} $0 == "AllUsers"
+			Call RunUninstaller
+  		${else}
+			!insertmacro UAC_AsUser_Call Function RunUninstaller ${UAC_SYNCREGISTERS}
+  		${endif}
 		${if} ${errors} ; stay in installer
 			SetErrorLevel 2 ; Installation aborted by script
 			BringToFront

--- a/Demos/MUI_1_2_Full/Setup.nsi
+++ b/Demos/MUI_1_2_Full/Setup.nsi
@@ -170,6 +170,7 @@ Section "Core Files (required)" SectionCoreFiles
 			${Switch} $0
 				${Case} 0 ; uninstaller completed successfully - continue with installation
 					BringToFront
+					Sleep 1000 ; wait for cmd.exe (called by the uninstaller) to finish
 					${Break}
 				${Case} 1 ; Installation aborted by user (cancel button)
 				${Case} 2 ; Installation aborted by script
@@ -182,6 +183,7 @@ Section "Core Files (required)" SectionCoreFiles
 			${EndSwitch}
 		${endif}
 
+		; Just a failsafe - should've been taken care of by cmd.exe
 		!insertmacro DeleteRetryAbort "$3\${UNINSTALL_FILENAME}" ; the uninstaller doesn't delete itself when not copied to the temp directory
 		RMDir "$3"
 	${endif}

--- a/Demos/MUI_1_2_Full/Setup.nsi
+++ b/Demos/MUI_1_2_Full/Setup.nsi
@@ -90,6 +90,7 @@ SetCompressor /SOLID lzma
 !insertmacro MUI_PAGE_STARTMENU "" "$StartMenuFolder"
 !define MUI_STARTMENUPAGE_DEFAULTFOLDER "${PRODUCT_NAME}" ; the MUI_PAGE_STARTMENU macro undefines MUI_STARTMENUPAGE_DEFAULTFOLDER, but we need it
 
+!define MUI_PAGE_CUSTOMFUNCTION_SHOW PageInstFilesPre
 !insertmacro MUI_PAGE_INSTFILES
 
 !define MUI_FINISHPAGE_RUN
@@ -311,6 +312,9 @@ Function PageInstallModeChangeMode
 FunctionEnd
 
 Function PageComponentsPre
+	GetDlgItem $0 $HWNDPARENT 1
+	SendMessage $0 ${BCM_SETSHIELD} 0 0 ; hide SHIELD (Windows Vista and above)
+
 	${if} $MultiUser.InstallMode == "AllUsers"
 		${if} ${AtLeastWin7} ; add "(current user only)" text to section "Start Menu Icon"
 			SectionGetText ${SectionStartMenuIcon} $0
@@ -324,11 +328,16 @@ Function PageComponentsPre
 FunctionEnd
 
 Function PageDirectoryPre
-	GetDlgItem $0 $HWNDPARENT 1
+	GetDlgItem $1 $HWNDPARENT 1
 	${if} ${SectionIsSelected} ${SectionProgramGroup}
-		SendMessage $0 ${WM_SETTEXT} 0 "STR:$(^NextBtn)" ; this is not the last page before installing
+		SendMessage $1 ${WM_SETTEXT} 0 "STR:$(^NextBtn)" ; this is not the last page before installing
+		SendMessage $1 ${BCM_SETSHIELD} 0 0 ; hide SHIELD (Windows Vista and above)
 	${else}
-		SendMessage $0 ${WM_SETTEXT} 0 "STR:$(^InstallBtn)" ; this is the last page before installing
+		SendMessage $1 ${WM_SETTEXT} 0 "STR:$(^InstallBtn)" ; this is the last page before installing
+		Call MultiUser.CheckPageElevationRequired
+		${if} $0 = 2
+			SendMessage $1 ${BCM_SETSHIELD} 0 1 ; display SHIELD (Windows Vista and above)
+		${endif}
 	${endif}
 FunctionEnd
 
@@ -347,7 +356,18 @@ FunctionEnd
 Function PageStartMenuPre
 	${ifnot} ${SectionIsSelected} ${SectionProgramGroup}
 		Abort ; don't display this dialog if SectionProgramGroup is not selected
+	${else}
+		GetDlgItem $1 $HWNDPARENT 1
+		Call MultiUser.CheckPageElevationRequired
+		${if} $0 = 2
+			SendMessage $1 ${BCM_SETSHIELD} 0 1 ; display SHIELD (Windows Vista and above)
+		${endif}
 	${endif}
+FunctionEnd
+
+Function PageInstFilesPre
+	GetDlgItem $0 $HWNDPARENT 1
+	SendMessage $0 ${BCM_SETSHIELD} 0 0 ; hide SHIELD (Windows Vista and above)
 FunctionEnd
 
 Function PageFinishRun

--- a/Demos/MUI_1_2_Full/Uninstall.nsh
+++ b/Demos/MUI_1_2_Full/Uninstall.nsh
@@ -55,6 +55,11 @@ Section "-Uninstall" ; hidden section, must always be the last one!
 	
 	; Remove the uninstaller from registry as the very last step - if sth. goes wrong, let the user run it again
 	!insertmacro MULTIUSER_RegistryRemoveInstallInfo ; Remove registry keys	
+
+	; If the uninstaller still exists, use cmd.exe on exit to remove it (along with $INSTDIR if it's empty)
+	${if} ${FileExists} "$INSTDIR\${UNINSTALL_FILENAME}"
+		Exec 'cmd.exe /c (del /f /q "$INSTDIR\${UNINSTALL_FILENAME}") && (rmdir "$INSTDIR")'
+	${endif}
 SectionEnd
 
 ; Modern install component descriptions

--- a/Demos/NSIS_Full/Setup.nsi
+++ b/Demos/NSIS_Full/Setup.nsi
@@ -73,6 +73,7 @@ PageEx directory
 PageExEnd
 
 PageEx instfiles
+	PageCallbacks PageInstFilesPre EmptyCallback EmptyCallback
 PageExEnd
 
 ; remove next line if you're using signing after the uninstaller is extracted from the initially compiled setup
@@ -288,6 +289,9 @@ Function PageWelcomeLicensePre
 FunctionEnd
 
 Function PageComponentsPre
+	GetDlgItem $0 $HWNDPARENT 1
+	SendMessage $0 ${BCM_SETSHIELD} 0 0 ; hide SHIELD (Windows Vista and above)
+
 	${if} $MultiUser.InstallMode == "AllUsers"
 		${if} ${AtLeastWin7} ; add "(current user only)" text to section "Start Menu Icon"
 			SectionGetText ${SectionStartMenuIcon} $0
@@ -301,11 +305,11 @@ Function PageComponentsPre
 FunctionEnd
 
 Function PageDirectoryPre
-	GetDlgItem $0 $HWNDPARENT 1
-	${if} ${SectionIsSelected} ${SectionProgramGroup}
-		SendMessage $0 ${WM_SETTEXT} 0 "STR:$(^NextBtn)" ; this is not the last page before installing
-	${else}
-		SendMessage $0 ${WM_SETTEXT} 0 "STR:$(^InstallBtn)" ; this is the last page before installing
+	GetDlgItem $1 $HWNDPARENT 1
+	SendMessage $1 ${WM_SETTEXT} 0 "STR:$(^InstallBtn)" ; this is the last page before installing
+	Call MultiUser.CheckPageElevationRequired
+	${if} $0 = 2
+		SendMessage $1 ${BCM_SETSHIELD} 0 1 ; display SHIELD (Windows Vista and above)
 	${endif}
 FunctionEnd
 
@@ -319,6 +323,11 @@ Function PageDirectoryShow
 		GetDlgItem $0 $R1 1001 ; Browse button
 		EnableWindow $0 0
 	${endif}
+FunctionEnd
+
+Function PageInstFilesPre
+	GetDlgItem $0 $HWNDPARENT 1
+	SendMessage $0 ${BCM_SETSHIELD} 0 0 ; hide SHIELD (Windows Vista and above)
 FunctionEnd
 
 Function .onUserAbort

--- a/Demos/NSIS_Full/Setup.nsi
+++ b/Demos/NSIS_Full/Setup.nsi
@@ -170,6 +170,7 @@ Section "Core Files (required)" SectionCoreFiles
 			${Switch} $0
 				${Case} 0 ; uninstaller completed successfully - continue with installation
 					BringToFront
+					Sleep 1000 ; wait for cmd.exe (called by the uninstaller) to finish
 					${Break}
 				${Case} 1 ; Installation aborted by user (cancel button)
 				${Case} 2 ; Installation aborted by script
@@ -182,6 +183,7 @@ Section "Core Files (required)" SectionCoreFiles
 			${EndSwitch}
 		${endif}
 
+		; Just a failsafe - should've been taken care of by cmd.exe
 		!insertmacro DeleteRetryAbort "$3\${UNINSTALL_FILENAME}" ; the uninstaller doesn't delete itself when not copied to the temp directory
 		RMDir "$3"
 	${endif}

--- a/Demos/NSIS_Full/Uninstall.nsh
+++ b/Demos/NSIS_Full/Uninstall.nsh
@@ -53,6 +53,11 @@ Section "-Uninstall" ; hidden section, must always be the last one!
 	
 	; Remove the uninstaller from registry as the very last step - if sth. goes wrong, let the user run it again
 	!insertmacro MULTIUSER_RegistryRemoveInstallInfo ; Remove registry keys	
+	
+	; If the uninstaller still exists, use cmd.exe on exit to remove it (along with $INSTDIR if it's empty)
+	${if} ${FileExists} "$INSTDIR\${UNINSTALL_FILENAME}"
+		Exec 'cmd.exe /c (del /f /q "$INSTDIR\${UNINSTALL_FILENAME}") && (rmdir "$INSTDIR")'
+	${endif}
 SectionEnd
 
 ; Callbacks

--- a/Demos/UMUI_Ex_Full/Setup.nsi
+++ b/Demos/UMUI_Ex_Full/Setup.nsi
@@ -189,6 +189,7 @@ Section "Core Files (required)" SectionCoreFiles
 			${Switch} $0
 				${Case} 0 ; uninstaller completed successfully - continue with installation
 					BringToFront
+					Sleep 1000 ; wait for cmd.exe (called by the uninstaller) to finish
 					${Break}
 				${Case} 1 ; Installation aborted by user (cancel button)
 				${Case} 2 ; Installation aborted by script
@@ -201,6 +202,7 @@ Section "Core Files (required)" SectionCoreFiles
 			${EndSwitch}
 		${endif}
 
+		; Just a failsafe - should've been taken care of by cmd.exe
 		!insertmacro DeleteRetryAbort "$3\${UNINSTALL_FILENAME}" ; the uninstaller doesn't delete itself when not copied to the temp directory
 		RMDir "$3"
 	${endif}

--- a/Demos/UMUI_Ex_Full/Uninstall.nsh
+++ b/Demos/UMUI_Ex_Full/Uninstall.nsh
@@ -62,6 +62,11 @@ Section "-Uninstall" ; hidden section, must always be the last one!
 	
 	; Remove the uninstaller from registry as the very last step - if sth. goes wrong, let the user run it again
 	!insertmacro MULTIUSER_RegistryRemoveInstallInfo ; Remove registry keys	
+
+	; If the uninstaller still exists, use cmd.exe on exit to remove it (along with $INSTDIR if it's empty)
+	${if} ${FileExists} "$INSTDIR\${UNINSTALL_FILENAME}"
+		Exec 'cmd.exe /c (del /f /q "$INSTDIR\${UNINSTALL_FILENAME}") && (rmdir "$INSTDIR")'
+	${endif}
 SectionEnd
 
 ; Modern install component descriptions

--- a/Include/NsisMultiUser.nsh
+++ b/Include/NsisMultiUser.nsh
@@ -301,7 +301,9 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 					!if ${MULTIUSER_INSTALLMODE_ALLOW_BOTH_INSTALLATIONS} = 0
 						${if} $HasPerMachineInstallation = 1
 							${andif} $HasPerUserInstallation = 0
-							StrCpy $0 1 ; has to uninstall the per-machine istalattion, which requires admin rights
+							; has to uninstall the per-machine installation, which requires admin rights
+							; but signle-user installs of standard users shouldn't be elevated (run as another user)
+							StrCpy $0 2
 						${endif}
 					!endif
 				!endif
@@ -981,6 +983,9 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 		Call ${UNINSTALLER_FUNCPREFIX}MultiUser.CheckPageElevationRequired
 		${if} $0 = 1
 			StrCpy $1 "$1 $(MULTIUSER_ADMIN_CREDENTIALS_REQUIRED)"
+		${elseif} $0 = 2
+		  StrCpy $1 "$1 $(MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED)"
+		  StrCpy $0 0
 		${endif}
 
 		SendMessage $MultiUser.InstallModePage.Description ${WM_SETTEXT} 0 "STR:$1"

--- a/Include/NsisMultiUser.nsh
+++ b/Include/NsisMultiUser.nsh
@@ -24,7 +24,7 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 
 ; exit and error codes
 !define MULTIUSER_ERROR_INVALID_PARAMETERS 666660 ; invalid command-line parameters
-!define MULTIUSER_ERROR_ELEVATION_NOT_ALLOWED 666661 ; elevation is restricted by MULTIUSER_INSTALLMODE_ALLOW_ELEVATION or MULTIUSER_INSTALLMODE_ALLOW_ELEVATION_IF_SILENT 
+!define MULTIUSER_ERROR_ELEVATION_NOT_ALLOWED 666661 ; elevation is restricted by MULTIUSER_INSTALLMODE_ALLOW_ELEVATION or MULTIUSER_INSTALLMODE_ALLOW_ELEVATION_IF_SILENT
 !define MULTIUSER_ERROR_NOT_INSTALLED 666662 ; returned from uninstaller when no version is installed
 !define MULTIUSER_ERROR_ELEVATION_FAILED 666666 ; returned by the outer instance when the inner instance cannot start (user aborted elevation dialog, Logon service not running, UAC is not supported by the OS, user without admin priv. is used in the runas dialog), or started, but was not admin
 !define MULTIUSER_INNER_INSTANCE_BACK 666667 ; returned by the inner instance when the user presses the Back button on the first visible page (display outer instance)
@@ -34,46 +34,46 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 	!ifndef PRODUCT_NAME | VERSION | PROGEXE
 		!error "Should define all variables: PRODUCT_NAME, VERSION, PROGEXE"
 	!endif
-	
+
 	; optional defines
 	; COMPANY_NAME - stored in uninstall info in registry
 	; MULTIUSER_INSTALLMODE_NO_HELP_DIALOG - don't show help dialog
 
-	!define /ifndef MULTIUSER_INSTALLMODE_ALLOW_BOTH_INSTALLATIONS 1 ; 0 or 1 - whether user can install BOTH per-user and per-machine; this only affects the texts and the required elevation on the page, the actual uninstall of previous version has to be implemented by script	
+	!define /ifndef MULTIUSER_INSTALLMODE_ALLOW_BOTH_INSTALLATIONS 1 ; 0 or 1 - whether user can install BOTH per-user and per-machine; this only affects the texts and the required elevation on the page, the actual uninstall of previous version has to be implemented by script
 	!define /ifndef MULTIUSER_INSTALLMODE_ALLOW_ELEVATION 1 ; 0 or 1, allow UAC screens in the (un)installer - if set to 0 and user is not admin, per-machine radiobutton will be disabled, or if elevation is always required, (un)installer will exit with an error code (and message if not silent)
 	!if "${MULTIUSER_INSTALLMODE_ALLOW_ELEVATION}" == "" ; old code - just defined with no value, equivalent to 1
 		!define /redef MULTIUSER_INSTALLMODE_ALLOW_ELEVATION 1
-	!endif	
-	!define /ifndef MULTIUSER_INSTALLMODE_ALLOW_ELEVATION_IF_SILENT 0 ; 0 or 1, (only available if MULTIUSER_INSTALLMODE_ALLOW_ELEVATION = 1) allow UAC screens in the (un)installer in silent mode; if set to 0 and user is not admin and elevation is always required, (un)installer will exit with an error code	
+	!endif
+	!define /ifndef MULTIUSER_INSTALLMODE_ALLOW_ELEVATION_IF_SILENT 0 ; 0 or 1, (only available if MULTIUSER_INSTALLMODE_ALLOW_ELEVATION = 1) allow UAC screens in the (un)installer in silent mode; if set to 0 and user is not admin and elevation is always required, (un)installer will exit with an error code
 	!if ${MULTIUSER_INSTALLMODE_ALLOW_ELEVATION} = 0
 		!if ${MULTIUSER_INSTALLMODE_ALLOW_ELEVATION_IF_SILENT} = 1
 			!error "MULTIUSER_INSTALLMODE_ALLOW_ELEVATION_IF_SILENT can be set only when MULTIUSER_INSTALLMODE_ALLOW_ELEVATION is set!"
 		!endif
-	!endif	
+	!endif
 	!define /ifndef MULTIUSER_INSTALLMODE_DEFAULT_ALLUSERS 0 ; 0 or 1, (only available if MULTIUSER_INSTALLMODE_ALLOW_ELEVATION = 1 and there are 0 or 2 installations on the system) when running as user and is set to 1, per-machine installation is pre-selected, otherwise per-user installation
 	!if "${MULTIUSER_INSTALLMODE_DEFAULT_ALLUSERS}" == "" ; old code - just defined with no value, equivalent to 1
 		!define /redef MULTIUSER_INSTALLMODE_DEFAULT_ALLUSERS 1
-	!endif	
+	!endif
 	!define /ifndef MULTIUSER_INSTALLMODE_DEFAULT_CURRENTUSER 0 ; 0 or 1, (only available if there are 0 or 2 installations on the system) when running as admin and is set to 1, per-user installation is pre-selected, otherwise per-machine installation
 	!if "${MULTIUSER_INSTALLMODE_DEFAULT_CURRENTUSER}" == "" ; old code - just defined with no value, equivalent to 1
 		!define /redef MULTIUSER_INSTALLMODE_DEFAULT_CURRENTUSER 1
-	!endif		
-	!define /ifndef MULTIUSER_INSTALLMODE_64_BIT 0 ; set to 1 for 64-bit installers	
+	!endif
+	!define /ifndef MULTIUSER_INSTALLMODE_64_BIT 0 ; set to 1 for 64-bit installers
 	!define /ifndef MULTIUSER_INSTALLMODE_INSTDIR "${PRODUCT_NAME}" ; suggested name of directory to install (under $PROGRAMFILES32/$PROGRAMFILES64 or $LOCALAPPDATA)
-	
-	!define /ifndef MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY "${PRODUCT_NAME}" ; registry key for UNINSTALL info, placed under [HKLM|HKCU]\Software\Microsoft\Windows\CurrentVersion\Uninstall	(can be ${PRODUCT_NAME} or some {GUID})	
-	!define /ifndef MULTIUSER_INSTALLMODE_INSTALL_REGISTRY_KEY "Microsoft\Windows\CurrentVersion\Uninstall\${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY}" ; registry key where InstallLocation is stored, placed under [HKLM|HKCU]\Software (can be ${PRODUCT_NAME} or some {GUID})	
+
+	!define /ifndef MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY "${PRODUCT_NAME}" ; registry key for UNINSTALL info, placed under [HKLM|HKCU]\Software\Microsoft\Windows\CurrentVersion\Uninstall	(can be ${PRODUCT_NAME} or some {GUID})
+	!define /ifndef MULTIUSER_INSTALLMODE_INSTALL_REGISTRY_KEY "Microsoft\Windows\CurrentVersion\Uninstall\${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY}" ; registry key where InstallLocation is stored, placed under [HKLM|HKCU]\Software (can be ${PRODUCT_NAME} or some {GUID})
 	!define MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH "Software\Microsoft\Windows\CurrentVersion\Uninstall\${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY}" ; full path to registry key storing uninstall information displayed in Windows installed programs list
-	!define MULTIUSER_INSTALLMODE_INSTALL_REGISTRY_KEY_PATH "Software\${MULTIUSER_INSTALLMODE_INSTALL_REGISTRY_KEY}" ; full path to registry key where InstallLocation is stored 		
-	!define /ifndef UNINSTALL_FILENAME "uninstall.exe" ; name of uninstaller	
-	!define /ifndef MULTIUSER_INSTALLMODE_DISPLAYNAME "${PRODUCT_NAME} ${VERSION}" ; display name in Windows uninstall list of programs	
+	!define MULTIUSER_INSTALLMODE_INSTALL_REGISTRY_KEY_PATH "Software\${MULTIUSER_INSTALLMODE_INSTALL_REGISTRY_KEY}" ; full path to registry key where InstallLocation is stored
+	!define /ifndef UNINSTALL_FILENAME "uninstall.exe" ; name of uninstaller
+	!define /ifndef MULTIUSER_INSTALLMODE_DISPLAYNAME "${PRODUCT_NAME} ${VERSION}" ; display name in Windows uninstall list of programs
 	!define /ifndef MULTIUSER_INSTALLMODE_INSTDIR_REGISTRY_VALUENAME "InstallLocation" ; name of the registry value containing install directory
-	
+
 	!ifdef MULTIUSER_INSTALLMODE_FUNCTION
 		!define MULTIUSER_INSTALLMODE_CHANGE_MODE_FUNCTION ${MULTIUSER_INSTALLMODE_FUNCTION} ; old code - changed function name
 		!undef MULTIUSER_INSTALLMODE_FUNCTION
-	!endif			
-	
+	!endif
+
 	; Variables
 	Var MultiUser.Privileges ; Current user level: "Admin", "Power" (up to Windows XP), or else regular user.
 	Var MultiUser.InstallMode ; Current Install Mode ("AllUsers" or "CurrentUser")
@@ -83,40 +83,40 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 	Var HasPerUserInstallation ; 0 or 1
 	Var HasCurrentModeInstallation ; 0 or 1
 	Var PerMachineInstallationVersion ; contains version number of empty string ""
-	Var PerUserInstallationVersion ; contains version number of empty string ""	
-	Var PerMachineInstallationFolder 
+	Var PerUserInstallationVersion ; contains version number of empty string ""
+	Var PerMachineInstallationFolder
 	Var PerUserInstallationFolder
 	Var PerMachineUninstallString
-	Var PerUserUninstallString	
+	Var PerUserUninstallString
 	Var PerMachineOptionAvailable ; 0 or 1: 0 means only per-user radio button is enabled on page, 1 means both; will be 0 only when MULTIUSER_INSTALLMODE_ALLOW_ELEVATION = 0 and user is not admin
 	Var InstallShowPagesBeforeComponents ; 0 or 1, when 0, use it to hide all pages before Components inside the installer when running as inner instance
 	Var DisplayDialog ; (internal)
 	Var PreFunctionCalled ; (internal)
 	Var CmdLineInstallMode ; contains command-line install mode set via /allusers and /currentusers parameters
 	Var CmdLineDir ; contains command-line directory set via /D parameter
-	
+
 	; interface variables
 	Var MultiUser.InstallModePage
 	Var MultiUser.InstallModePage.Text
 	Var MultiUser.InstallModePage.AllUsers
-	Var MultiUser.InstallModePage.CurrentUser	
+	Var MultiUser.InstallModePage.CurrentUser
 	Var MultiUser.InstallModePage.AllUsersLabel
 	Var MultiUser.InstallModePage.CurrentUserLabel
 	Var MultiUser.InstallModePage.Description
-!macroend	
+!macroend
 
 !macro MULTIUSER_UNINIT_VARS
-	!ifdef MULTIUSER_INSTALLMODE_UNFUNCTION		
+	!ifdef MULTIUSER_INSTALLMODE_UNFUNCTION
 		!define MULTIUSER_INSTALLMODE_CHANGE_MODE_FUNCTION ${MULTIUSER_INSTALLMODE_UNFUNCTION} ; old code - changed function name
 		!undef MULTIUSER_INSTALLMODE_UNFUNCTION
-	!else ifdef MULTIUSER_INSTALLMODE_CHANGE_MODE_UNFUNCTION 	
+	!else ifdef MULTIUSER_INSTALLMODE_CHANGE_MODE_UNFUNCTION
 		!define MULTIUSER_INSTALLMODE_CHANGE_MODE_FUNCTION ${MULTIUSER_INSTALLMODE_CHANGE_MODE_UNFUNCTION} ; old code - changed function name
-		!undef MULTIUSER_INSTALLMODE_CHANGE_MODE_UNFUNCTION	
-	!endif		
+		!undef MULTIUSER_INSTALLMODE_CHANGE_MODE_UNFUNCTION
+	!endif
 
 	; Variables
 	Var UninstallShowBackButton ; 0 or 1, use it to show/hide the Back button on the first visible page of the uninstaller
-!macroend	
+!macroend
 
 /****** Modern UI 2 page ******/
 !macro MULTIUSER_PAGE UNINSTALLER_PREFIX UNINSTALLER_FUNCPREFIX
@@ -128,20 +128,20 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 	${${UNINSTALLER_PREFIX}StrRep}
 
 	!insertmacro MULTIUSER_${UNINSTALLER_PREFIX}INIT_VARS
-	
+
 	!ifmacrodef MUI_${UNINSTALLER_PREFIX}PAGE_INIT
 		!insertmacro MUI_${UNINSTALLER_PREFIX}PAGE_INIT
-	!endif	
-	
+	!endif
+
 	!insertmacro MULTIUSER_FUNCTION_INSTALLMODEPAGE "${UNINSTALLER_PREFIX}" "${UNINSTALLER_FUNCPREFIX}"
 
 	PageEx ${UNINSTALLER_FUNCPREFIX}custom
 		PageCallbacks ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallModePre ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallModeLeave
-	PageExEnd	
-	
+	PageExEnd
+
 	!ifmacrodef MUI_${UNINSTALLER_PREFIX}PAGE_END
 		!insertmacro MUI_${UNINSTALLER_PREFIX}PAGE_END ; MUI1 MUI_UNPAGE_END macro
-	!endif	
+	!endif
 !macroend
 
 !macro MULTIUSER_PAGE_INSTALLMODE ; create install page - called by user script
@@ -167,7 +167,7 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 	!define MULTIUSER_INIT
 
 	!ifndef MULTIUSER_PAGE_INSTALLMODE
-		!error "You have to insert MULTIUSER_PAGE_INSTALLMODE!" 
+		!error "You have to insert MULTIUSER_PAGE_INSTALLMODE!"
 	!endif
 
 	Call MultiUser.InitChecks
@@ -177,12 +177,12 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 	!ifdef MULTIUSER_UNINIT
 		!error "MULTIUSER_UNINIT already inserted!"
 	!endif
-	!define MULTIUSER_UNINIT	
-	
+	!define MULTIUSER_UNINIT
+
 	!ifndef MULTIUSER_PAGE_INSTALLMODE | MULTIUSER_UNPAGE_INSTALLMODE
-		!error "You have to insert both MULTIUSER_PAGE_INSTALLMODE and MULTIUSER_UNPAGE_INSTALLMODE!" 
-	!endif	
-	
+		!error "You have to insert both MULTIUSER_PAGE_INSTALLMODE and MULTIUSER_UNPAGE_INSTALLMODE!"
+	!endif
+
 	Call un.MultiUser.InitChecks
 !macroend
 
@@ -205,16 +205,16 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 		${endif}
 
 		StrCpy $MultiUser.InstallMode "AllUsers"
-	
+
 		SetShellVarContext all
 
 		StrCpy $HasCurrentModeInstallation "$HasPerMachineInstallation"
-		
+
 		${if} $CmdLineDir != ""
 			StrCpy $INSTDIR $CmdLineDir
 		${elseif} $PerMachineInstallationFolder != ""
 			StrCpy $INSTDIR $PerMachineInstallationFolder
-		${else}			
+		${else}
 			!if "${UNINSTALLER_FUNCPREFIX}" == ""
 				; Set default installation location for installer
 				${if} ${MULTIUSER_INSTALLMODE_64_BIT} = 0
@@ -223,29 +223,29 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 					StrCpy $INSTDIR "$PROGRAMFILES64\${MULTIUSER_INSTALLMODE_INSTDIR}"
 				${endif}
 			!endif
-		${endif}	
+		${endif}
 
 		!ifdef MULTIUSER_INSTALLMODE_CHANGE_MODE_FUNCTION
 			Call "${MULTIUSER_INSTALLMODE_CHANGE_MODE_FUNCTION}"
-		!endif		
+		!endif
 	FunctionEnd
 
 	Function ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallMode.CurrentUser
 		${if} $MultiUser.InstallMode == "CurrentUser"
 			Return
-		${endif}		
-		
+		${endif}
+
 		StrCpy $MultiUser.InstallMode "CurrentUser"
-	
+
 		SetShellVarContext current
-		
+
 		StrCpy $HasCurrentModeInstallation "$HasPerUserInstallation"
-		
+
 		${if} $CmdLineDir != ""
 			StrCpy $INSTDIR $CmdLineDir
 		${elseif} $PerUserInstallationFolder != ""
 			StrCpy $INSTDIR $PerUserInstallationFolder
-		${else}			
+		${else}
 			!if "${UNINSTALLER_FUNCPREFIX}" == ""
 				; Set default installation location for installer
 				${if} "$LOCALAPPDATA" != ""
@@ -262,48 +262,48 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 					${endif}
 				${endif}
 			!endif
-		${endif}	
-		
+		${endif}
+
 		!ifdef MULTIUSER_INSTALLMODE_CHANGE_MODE_FUNCTION
 			Call "${MULTIUSER_INSTALLMODE_CHANGE_MODE_FUNCTION}"
-			!undef MULTIUSER_INSTALLMODE_CHANGE_MODE_FUNCTION 
+			!undef MULTIUSER_INSTALLMODE_CHANGE_MODE_FUNCTION
 		!endif
 	FunctionEnd
 
 	Function ${UNINSTALLER_FUNCPREFIX}MultiUser.GetPos
 		StrCpy $2 $PreFunctionCalled ; if not PreFunctionCalled, we cannot get position
-		
+
 		${if} $2 = 1
 			System::Call "*(i, i, i, i) p .r3" ; allocate RECT struct
-			
+
 			System::Call "User32::GetWindowRect(p $HWNDPARENT, i r3)"
-			
+
 			System::Call '*$3(i .r0, i .r1, i, i)'
-			
+
 			System::Free $3
-		${endif}	
+		${endif}
 	FunctionEnd
-	
+
 	Function ${UNINSTALLER_FUNCPREFIX}MultiUser.SetPos
 		System::Call "User32::SetWindowPos(p $HWNDPARENT, i 0, i $0, i $1, i 0, i 0, i 0x5)"
-	FunctionEnd	
+	FunctionEnd
 
 	Function ${UNINSTALLER_FUNCPREFIX}MultiUser.CheckPageElevationRequired
 		; check if elevation on page is always required, return result in $0
 		; when this function is called from InitChecks, InstallMode is ""
-		; and when called from InstallModeLeave/SetShieldsAndTexts, InstallMode is not empty 
+		; and when called from InstallModeLeave/SetShieldsAndTexts, InstallMode is not empty
 		StrCpy $0 0
 		${if} $IsAdmin = 0
 			${if} $MultiUser.InstallMode == "AllUsers"
 				StrCpy $0 1
-			${else} 
+			${else}
 				!if "${UNINSTALLER_FUNCPREFIX}" == "" ; installer
 					!if ${MULTIUSER_INSTALLMODE_ALLOW_BOTH_INSTALLATIONS} = 0
 						${if} $HasPerMachineInstallation = 1
 							${andif} $HasPerUserInstallation = 0
 							StrCpy $0 1 ; has to uninstall the per-machine istalattion, which requires admin rights
-						${endif}			
-					!endif				
+						${endif}
+					!endif
 				!endif
 			${endif}
 		${endif}
@@ -315,20 +315,20 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 		${else}
 			StrCpy $0 "${MULTIUSER_INSTALLMODE_ALLOW_ELEVATION}"
 		${endif}
-	FunctionEnd	
-	
+	FunctionEnd
+
 	Function ${UNINSTALLER_FUNCPREFIX}MultiUser.Elevate
 		Call ${UNINSTALLER_FUNCPREFIX}MultiUser.CheckElevationAllowed
-		
+
 		${if} $0 = 0
 			Return
 		${endif}
-		
+
 		HideWindow
 		!insertmacro UAC_RunElevated
 		${if} $0 = 0
 			; if inner instance was started ($1 = 1), return code of the elevated fork process is in $2 as well as set via SetErrorLevel
-			; NOTE: the error level may have a value MULTIUSER_ERROR_ELEVATION_FAILED (but not MULTIUSER_ERROR_ELEVATION_NOT_ALLOWED)		
+			; NOTE: the error level may have a value MULTIUSER_ERROR_ELEVATION_FAILED (but not MULTIUSER_ERROR_ELEVATION_NOT_ALLOWED)
 			${if} $1 <> 1 ; process did not start - return MULTIUSER_ERROR_ELEVATION_FAILED
 				SetErrorLevel ${MULTIUSER_ERROR_ELEVATION_FAILED}
 			${endif}
@@ -336,24 +336,24 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 			${if} $0 = 1223 ; user aborted elevation dialog - translate to MULTIUSER_ERROR_ELEVATION_FAILED for easier processing
 				${orif} $0 = 1062 ; Logon service not running - translate to MULTIUSER_ERROR_ELEVATION_FAILED for easier processing
 				StrCpy $0 ${MULTIUSER_ERROR_ELEVATION_FAILED}
-			${endif}	
+			${endif}
 			SetErrorLevel $0
 		${endif}
-		Quit 
-	FunctionEnd		
-	
+		Quit
+	FunctionEnd
+
 	Function ${UNINSTALLER_FUNCPREFIX}MultiUser.InitChecks
-		System::Store S 
-		
-		; Installer initialization - check privileges and set default install mode	
+		System::Store S
+
+		; Installer initialization - check privileges and set default install mode
 		StrCpy $MultiUser.InstallMode ""
 		StrCpy $PerMachineOptionAvailable 1
 		StrCpy $InstallShowPagesBeforeComponents 1
 		StrCpy $DisplayDialog 1
-		StrCpy $PreFunctionCalled 0	
+		StrCpy $PreFunctionCalled 0
 		StrCpy $CmdLineInstallMode ""
 		StrCpy $CmdLineDir ""
-		
+
 		${if} ${RunningX64} ; fix for https://github.com/Drizin/NsisMultiUser/issues/11
 			${if} ${MULTIUSER_INSTALLMODE_64_BIT} = 0
 				; HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall gets redirected to HKLM\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall,
@@ -361,9 +361,9 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 				SetRegView 32 ; someday, when NSIS is 64-bit...
 			${else}
 				SetRegView 64
-			${endif}		
+			${endif}
 		${endif}
-										
+
 		UserInfo::GetAccountType
 		Pop $MultiUser.Privileges
 		${if} $MultiUser.Privileges == "Admin"
@@ -372,8 +372,8 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 		${else}
 			StrCpy $IsAdmin 0
 		${endif}
-		
-		${if} ${UAC_IsInnerInstance}	
+
+		${if} ${UAC_IsInnerInstance}
 			StrCpy $IsInnerInstance 1
 		${else}
 			StrCpy $IsInnerInstance 0
@@ -381,17 +381,17 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 
 		; initialize PerXXXInstallationFolder, PerXXXInstallationVersion, PerXXXUninstallString variables
 		ReadRegStr $PerMachineInstallationFolder HKLM "${MULTIUSER_INSTALLMODE_INSTALL_REGISTRY_KEY_PATH}" "${MULTIUSER_INSTALLMODE_INSTDIR_REGISTRY_VALUENAME}" ; "InstallLocation"
-		ReadRegStr $PerMachineInstallationVersion HKLM "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}" "DisplayVersion"		
+		ReadRegStr $PerMachineInstallationVersion HKLM "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}" "DisplayVersion"
 		ReadRegStr $PerMachineUninstallString HKLM "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}" "UninstallString" ; contains the /currentuser or /allusers parameter
 		${if} $PerMachineInstallationFolder == ""
 			StrCpy $HasPerMachineInstallation 0
 		${else}
 			StrCpy $HasPerMachineInstallation 1
 		${endif}
-				
+
 		ReadRegStr $PerUserInstallationFolder HKCU "${MULTIUSER_INSTALLMODE_INSTALL_REGISTRY_KEY_PATH}" "${MULTIUSER_INSTALLMODE_INSTDIR_REGISTRY_VALUENAME}" ; "InstallLocation"
 		!insertmacro MULTIUSER_GetCurrentUserString $0
-		ReadRegStr $PerUserInstallationVersion HKCU "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}$0" "DisplayVersion"				
+		ReadRegStr $PerUserInstallationVersion HKCU "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}$0" "DisplayVersion"
 		ReadRegStr $PerUserUninstallString HKCU "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}$0" "UninstallString" ; contains the /currentuser or /allusers parameter
 		${if} $PerUserInstallationFolder == ""
 			StrCpy $HasPerUserInstallation 0
@@ -400,56 +400,56 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 			${if} $PerUserInstallationVersion == ""
 				${andif} $0 != ""
 				; support old versions that did not have MULTIUSER_GetCurrentUserString
-				ReadRegStr $PerUserInstallationVersion HKCU "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}" "DisplayVersion"				
-				ReadRegStr $PerUserUninstallString HKCU "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}" "UninstallString" ; contains the /currentuser or /allusers parameter				
-			${endif}	
+				ReadRegStr $PerUserInstallationVersion HKCU "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}" "DisplayVersion"
+				ReadRegStr $PerUserUninstallString HKCU "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}" "UninstallString" ; contains the /currentuser or /allusers parameter
+			${endif}
 		${endif}
-			
+
 		; get all parameters
 		${GetParameters} $R0
-	
+
 		; initialize CmdLineInstallMode and CmdLineDir, needed also if we are the inner instance (UAC passes all parameters from the outer instance)
-		; note: the loading of the /D parameter depends on AllowRootDirInstall, see https://sourceforge.net/p/nsis/bugs/1176/ 
+		; note: the loading of the /D parameter depends on AllowRootDirInstall, see https://sourceforge.net/p/nsis/bugs/1176/
 		${GetOptions} $R0 "/allusers" $R1
 		${ifnot} ${errors}
 			StrCpy $CmdLineInstallMode "AllUsers"
-		${endif}	
-		
+		${endif}
+
 		${GetOptions} $R0 "/currentuser" $R1
 		${ifnot} ${errors}
 			${if} $CmdLineInstallMode != ""
 				!insertmacro MULTIUSER_SET_ERROR ${MULTIUSER_ERROR_INVALID_PARAMETERS}
 			${endif}
 			StrCpy $CmdLineInstallMode "CurrentUser"
-		${endif}		
-		
+		${endif}
+
 		!if "${UNINSTALLER_FUNCPREFIX}" == ""
 			${if} "$INSTDIR" != "" ; if $INSTDIR is not empty here in the installer, it's initialized with the value of the /D command-line parameter
 				StrCpy $CmdLineDir "$INSTDIR"
 			${endif}
 		!endif
-	
+
 		; initialize $InstallShowPagesBeforeComponents and $UninstallShowBackButton
-		!if "${UNINSTALLER_FUNCPREFIX}" == ""			
+		!if "${UNINSTALLER_FUNCPREFIX}" == ""
 			${if} $IsInnerInstance = 1
 				StrCpy $InstallShowPagesBeforeComponents 0 ; we hide pages only if we're the inner instance (the outer instance always shows them)
-			${endif}	
-		!else				
+			${endif}
+		!else
 			${if} $CmdLineInstallMode == ""
 				${andif} $HasPerMachineInstallation = 1
 				${andif} $HasPerUserInstallation = 1
 				StrCpy $UninstallShowBackButton 1 ; make sure we show Back button only if dialog was displayed, i.e. uninstaller did not elevate in the beginning (see when MultiUser.Elevate is called)
-			${else}		
+			${else}
 				StrCpy $UninstallShowBackButton 0
-			${endif}			
-		!endif			
+			${endif}
+		!endif
 
 		${if} $IsInnerInstance = 1
 			; check if the inner instance has admin rights
 			${if} $IsAdmin = 0
 				SetErrorLevel ${MULTIUSER_ERROR_ELEVATION_FAILED} ; special return value for outer instance so it knows we did not have admin rights
 				Quit
-			${endif}	
+			${endif}
 
 			!if "${UNINSTALLER_FUNCPREFIX}" == ""
 				; set language to the one used in the outer instance (installer only, for uninstaller the outer and inner instance might have different language,
@@ -459,13 +459,13 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 				!if ${MULTIUSER_INSTALLMODE_ALLOW_BOTH_INSTALLATIONS} = 0
 					!insertmacro UAC_AsUser_GetGlobal $0 $MultiUser.InstallMode
 					${if} $0 == "CurrentUser"
-						; the inner instance was elevated because there is installation per-machine, which needs to be removed and requires admin rights, 
+						; the inner instance was elevated because there is installation per-machine, which needs to be removed and requires admin rights,
 						; but the user selected per-user installation in the outer instance, set context to CurrentUser
 						Call MultiUser.InstallMode.CurrentUser
 						StrCpy $DisplayDialog 0
-						System::Store L 
+						System::Store L
 						Return
-					${endif}	
+					${endif}
 				!endif
 			!endif
 
@@ -473,9 +473,9 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 			StrCpy $DisplayDialog 0
 			System::Store L
  			Return
-		${endif}	
-		
-		; process /? parameter		
+		${endif}
+
+		; process /? parameter
 		!ifndef MULTIUSER_INSTALLMODE_NO_HELP_DIALOG ; define MULTIUSER_INSTALLMODE_NO_HELP_DIALOG to display your own help dialog (new options, return codes, etc.)
 			${GetOptions} $R0 "/?" $R1
 			${ifnot} ${errors}
@@ -502,13 +502,13 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 					other$\t- Windows error code when trying to start elevated instance"
 				SetErrorLevel 0
 				Quit
-			${endif}		
-		!endif	
+			${endif}
+		!endif
 
 		; process /uninstall parameter
 		!if "${UNINSTALLER_FUNCPREFIX}" == ""
 			${GetOptions} $R0 "/uninstall" $R1
-			${ifnot} ${errors}			
+			${ifnot} ${errors}
 				${if} $CmdLineInstallMode == ""
 					!insertmacro MULTIUSER_SET_ERROR ${MULTIUSER_ERROR_INVALID_PARAMETERS}
 				${elseif} $CmdLineInstallMode == "AllUsers"
@@ -522,64 +522,64 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 					${endif}
 					StrCpy $0 "$PerUserInstallationFolder"
 				${endif}
-				
-				; NOTES: 
+
+				; NOTES:
 				; - the _? param stops the uninstaller from copying itself to the temporary directory, which is the only way for waiting to work
 				; - $R0 passes the original parameters from the installer to the uninstaller (together with /uninstall so that uninstaller knows installer is running and skips opitional single instance checks)
 				; - using ExecWait fails if the new process requires elevation, see http://forums.winamp.com/showthread.php?p=3080202&posted=1#post3080202, so we use ShellExecuteEx
-				System::Call '*(i 60, i 0x140, i 0, t "open", t "$0\${UNINSTALL_FILENAME}", t "$R0 _?=$0", t, i ${SW_SHOW}, i, i, t, i, i, i, i) p .r2' ; allocate and fill values for SHELLEXECUTEINFO structure, returned in $2 (0x140 = SEE_MASK_NOCLOSEPROCESS|SEE_MASK_NOASYNC)	
-				
+				System::Call '*(i 60, i 0x140, i 0, t "open", t "$0\${UNINSTALL_FILENAME}", t "$R0 _?=$0", t, i ${SW_SHOW}, i, i, t, i, i, i, i) p .r2' ; allocate and fill values for SHELLEXECUTEINFO structure, returned in $2 (0x140 = SEE_MASK_NOCLOSEPROCESS|SEE_MASK_NOASYNC)
+
 				System::Call 'shell32::ShellExecuteEx(i r2) i .r0 ?e'
 				Pop $1
 				${if} $0 = 0
 					SetErrorLevel $1
 					Quit
 				${endif}
-				
+
 				System::Call '*$2(i, i, i, t, t, t, t, i, i, i, t, i, i, i, i .r3)' ; get the process handle in $3
-				
+
 				System::Call 'kernel32::WaitForSingleObject(i r3, i -1) i .r0 ?e' ; wait indefinitely for the process to exit
 				Pop $1
 				${if} $0 <> 0 ; WAIT_OBJECT_0
 					SetErrorLevel $1
 					Quit
 				${endif}
-				
+
 				System::Call 'kernel32::GetExitCodeProcess(i r3, *i .r4) i .r0 ?e' ; store exit code in $4
 				Pop $1
 				${if} $0 = 0
 					SetErrorLevel $1
 					Quit
 				${endif}
-				
+
 				System::Call 'Kernel32::CloseHandle(i r3)' ; close the process handle in $3
-				System::Free $2 ; free SHELLEXECUTEINFO structure, stored in $2 
-				
+				System::Free $2 ; free SHELLEXECUTEINFO structure, stored in $2
+
 				SetErrorLevel $4 ; return exit code stored in $4
 				Quit
-			${endif}		
+			${endif}
 		!endif
-						
+
 		; check for limitations
 		${if} ${silent}
 			${andif} $CmdLineInstallMode == ""
 			SetErrorLevel ${MULTIUSER_ERROR_INVALID_PARAMETERS} ; one of the /allusers or /currentuser parameters is required in silent mode
 			Quit
-		${endif}		
-		
+		${endif}
+
 		!if "${UNINSTALLER_FUNCPREFIX}" != ""
 			${if} $HasPerMachineInstallation = 0
 				${andif} $HasPerUserInstallation = 0
 				!insertmacro MULTIUSER_SET_ERROR ${MULTIUSER_ERROR_NOT_INSTALLED}
 			${endif}
 		!endif
-									
+
 		; process /allusers and /currentuser parameters (both silent and non-silent mode, installer and uninstaller)
-		${if} $CmdLineInstallMode != ""	
-			${ifnot} ${IsNT} ; Not running Windows NT, (so it's Windows 95/98/ME), so per-user installation not supported					
+		${if} $CmdLineInstallMode != ""
+			${ifnot} ${IsNT} ; Not running Windows NT, (so it's Windows 95/98/ME), so per-user installation not supported
 				${andif} $CmdLineInstallMode == "CurrentUser"
 				!insertmacro MULTIUSER_SET_ERROR ${MULTIUSER_ERROR_INVALID_PARAMETERS}
-			${endif}			
+			${endif}
 
 			${if} $CmdLineInstallMode == "AllUsers"
 				Call ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallMode.AllUsers
@@ -591,39 +591,39 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 				${if} $HasCurrentModeInstallation = 0
 					!insertmacro MULTIUSER_SET_ERROR ${MULTIUSER_ERROR_NOT_INSTALLED}
 				${endif}
-			!endif	
+			!endif
 
 			!if "${UNINSTALLER_FUNCPREFIX}" != ""
 				StrCpy $DisplayDialog 0 ; uninstaller - don't display dialog when there is /allusers or /currentuser parameter
-			!else	
+			!else
 				${if} ${silent}
 					StrCpy $DisplayDialog 0
-				${endif}	
-			!endif	
+				${endif}
+			!endif
 
 			Call ${UNINSTALLER_FUNCPREFIX}MultiUser.CheckPageElevationRequired
 			${if} $0 = 1
 				${if} $DisplayDialog = 0 ; if we are not displaying the dialog (uninstaller or silent mode) and elevation is required, Elevate now (or Quit with an error)
 					Call ${UNINSTALLER_FUNCPREFIX}MultiUser.Elevate
-				${else}	
+				${else}
 					Call ${UNINSTALLER_FUNCPREFIX}MultiUser.CheckElevationAllowed ; if we are displaying the dialog and elevation is required, check if elevation is allowed
 				${endif}
 				${if} $0 = 0
 					!insertmacro MULTIUSER_SET_ERROR ${MULTIUSER_ERROR_ELEVATION_NOT_ALLOWED}
 				${endif}
-			${endif}				
-			System::Store L 
+			${endif}
+			System::Store L
 			Return
-		${endif}		
-				
-		; the rest of the code is executed only when there are no /allusers and /currentuser parameters and in non-silent mode		
+		${endif}
+
+		; the rest of the code is executed only when there are no /allusers and /currentuser parameters and in non-silent mode
 		${ifnot} ${IsNT} ; Not running Windows NT, (so it's Windows 95/98/ME), so per-user installation not supported
-			Call ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallMode.AllUsers	
+			Call ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallMode.AllUsers
 			StrCpy $DisplayDialog 0
-			System::Store L 
+			System::Store L
 			Return
-		${endif}	
-		
+		${endif}
+
 		; check if elevation on page is always required (installer only)
 		!if "${UNINSTALLER_FUNCPREFIX}" == ""
 			Call ${UNINSTALLER_FUNCPREFIX}MultiUser.CheckPageElevationRequired
@@ -632,14 +632,14 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 				${if} $0 = 0
 					!insertmacro MULTIUSER_SET_ERROR ${MULTIUSER_ERROR_ELEVATION_NOT_ALLOWED}
 				${endif}
-			${endif}	
-		!endif	
+			${endif}
+		!endif
 
 		; if elevation is not allowed and user is not admin, disable the per-machine option
 		!if ${MULTIUSER_INSTALLMODE_ALLOW_ELEVATION} = 0
 			${if} $IsAdmin = 0
-				StrCpy $PerMachineOptionAvailable 0				
-			${endif}	
+				StrCpy $PerMachineOptionAvailable 0
+			${endif}
 		!endif
 
 		; if there's only one installed version
@@ -651,27 +651,27 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 					Call ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallMode.AllUsers
 				${else}
 					Call ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallMode.CurrentUser
-				${endif}				
+				${endif}
 			!else
 				${if} $IsAdmin = 0
-					Call ${UNINSTALLER_FUNCPREFIX}MultiUser.Elevate ; if $PerMachineOptionAvailable = 0 (i.e. MULTIUSER_INSTALLMODE_ALLOW_ELEVATION = 0), Elevate will call CheckElevationAllowed, which checks if MULTIUSER_INSTALLMODE_ALLOW_ELEVATION = 0 
+					Call ${UNINSTALLER_FUNCPREFIX}MultiUser.Elevate ; if $PerMachineOptionAvailable = 0 (i.e. MULTIUSER_INSTALLMODE_ALLOW_ELEVATION = 0), Elevate will call CheckElevationAllowed, which checks if MULTIUSER_INSTALLMODE_ALLOW_ELEVATION = 0
 					${if} $0 = 0
 						!insertmacro MULTIUSER_SET_ERROR ${MULTIUSER_ERROR_ELEVATION_NOT_ALLOWED}
 					${endif}
 				${endif}
 				Call ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallMode.AllUsers
-				StrCpy $DisplayDialog 0							
+				StrCpy $DisplayDialog 0
 			!endif
 		${elseif} $HasPerMachineInstallation = 0
 			${andif} $HasPerUserInstallation = 1
 			Call ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallMode.CurrentUser
 			!if "${UNINSTALLER_FUNCPREFIX}" != ""
-				StrCpy $DisplayDialog 0				
-			!endif							
-		${else} ; if there is no installed version (installer only), or there are 2 installations - we always display the dialog 
+				StrCpy $DisplayDialog 0
+			!endif
+		${else} ; if there is no installed version (installer only), or there are 2 installations - we always display the dialog
 			${if} $IsAdmin = 1 ; If running as admin, default to per-machine installation (unless default is forced by MULTIUSER_INSTALLMODE_DEFAULT_CURRENTUSER)
 				!if ${MULTIUSER_INSTALLMODE_DEFAULT_CURRENTUSER} = 0
-					Call ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallMode.AllUsers					
+					Call ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallMode.AllUsers
 				!else
 					Call ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallMode.CurrentUser
 				!endif
@@ -680,27 +680,27 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 					Call ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallMode.CurrentUser
 				!else
 					${if} $PerMachineOptionAvailable = 1
-						Call ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallMode.AllUsers 				
+						Call ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallMode.AllUsers
 					${else}
 						Call ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallMode.CurrentUser
-					${endif}						
+					${endif}
 				!endif
 			${endif}
-		${endif}		
-		
-		System::Store L 
+		${endif}
+
+		System::Store L
 	FunctionEnd
 
 	Function ${UNINSTALLER_FUNCPREFIX}MultiUser.ShowErrorMessage
  		Push $0
- 		
+
 		GetErrorLevel $0
-		
+
 		${if} $0 = -1
 			Pop $0
 			Return
 		${endif}
-		
+
 		${Switch} $0
 			${Case} ${MULTIUSER_ERROR_INVALID_PARAMETERS}
 				MessageBox MB_ICONSTOP "$(MULTIUSER_INVALID_PARAMS)" /SD IDOK
@@ -713,35 +713,35 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 				Quit
 		${EndSwitch}
 	FunctionEnd
-			
+
 	Function ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallModePre
-		System::Store S 
-		
+		System::Store S
+
 		Call ${UNINSTALLER_FUNCPREFIX}MultiUser.ShowErrorMessage
-						
+
 		${if} $IsInnerInstance = 1
 			${if} $PreFunctionCalled = 0 ; inner instance is displayed
 				; set position of inner instance
 				!insertmacro UAC_AsUser_Call Function ${UNINSTALLER_FUNCPREFIX}MultiUser.GetPos ${UAC_SYNCREGISTERS}
 				${if} $2 = 1
-					Call ${UNINSTALLER_FUNCPREFIX}MultiUser.SetPos			
-				${endif}	
+					Call ${UNINSTALLER_FUNCPREFIX}MultiUser.SetPos
+				${endif}
 			${else} ; user pressed Back button on the first visible page in the inner instance - display outer instance
 				; set position of outer instance
-				Call ${UNINSTALLER_FUNCPREFIX}MultiUser.GetPos							
-				!insertmacro UAC_AsUser_Call Function ${UNINSTALLER_FUNCPREFIX}MultiUser.SetPos ${UAC_SYNCREGISTERS}				
-							
+				Call ${UNINSTALLER_FUNCPREFIX}MultiUser.GetPos
+				!insertmacro UAC_AsUser_Call Function ${UNINSTALLER_FUNCPREFIX}MultiUser.SetPos ${UAC_SYNCREGISTERS}
+
 				SetErrorLevel ${MULTIUSER_INNER_INSTANCE_BACK}
-				Quit	
+				Quit
 			${endif}
-		${endif}				
+		${endif}
 		StrCpy $PreFunctionCalled 1
-		
+
 		${if} $DisplayDialog = 0
-			System::Store L 
+			System::Store L
 			Abort
-		${endif}		
-						
+		${endif}
+
 		!ifmacrodef MUI_HEADER_TEXT
 			!if "${UNINSTALLER_FUNCPREFIX}" == ""
 				!insertmacro MUI_HEADER_TEXT "$(MULTIUSER_PAGE_TITLE)" "$(MULTIUSER_INSTALL_PAGE_SUBTITLE)"
@@ -749,13 +749,13 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 				!insertmacro MUI_HEADER_TEXT "$(MULTIUSER_PAGE_TITLE)" "$(MULTIUSER_UNINSTALL_PAGE_SUBTITLE)"
 			!endif
 		!endif
-		
+
 		!ifdef MUI_PAGE_CUSTOMFUNCTION_PRE
 			Call "${MUI_PAGE_CUSTOMFUNCTION_PRE}"
 			!undef MUI_PAGE_CUSTOMFUNCTION_PRE
 		!endif
 		nsDialogs::Create 1018
-		Pop $MultiUser.InstallModePage		
+		Pop $MultiUser.InstallModePage
 
 		; default was MULTIUSER_TEXT_INSTALLMODE_TITLE "Choose Users"
 		!if "${UNINSTALLER_FUNCPREFIX}" == ""
@@ -765,95 +765,95 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 		!endif
 		Pop $MultiUser.InstallModePage.Text
 
-		StrCpy $0 "$(MULTIUSER_ALL_USERS)" 
-		${NSD_CreateRadioButton} 30u 30% 10u 8u ""	
-		Pop $MultiUser.InstallModePage.AllUsers	
-		
+		StrCpy $0 "$(MULTIUSER_ALL_USERS)"
+		${NSD_CreateRadioButton} 30u 30% 10u 8u ""
+		Pop $MultiUser.InstallModePage.AllUsers
+
 		System::Call "advapi32::GetUserName(t. r1, *i ${NSIS_MAX_STRLEN})"
 		${${UNINSTALLER_PREFIX}StrRep} "$1" "$(MULTIUSER_CURRENT_USER)" "{USER}" "$1"
-		${NSD_CreateRadioButton} 30u 45% 10u 8u ""	
-		Pop $MultiUser.InstallModePage.CurrentUser 
-		
+		${NSD_CreateRadioButton} 30u 45% 10u 8u ""
+		Pop $MultiUser.InstallModePage.CurrentUser
+
 		; We create the radio buttons with empty text and create separate labels, because radio button font color can't be changed with XP Styles turned on,
 		; which creates problems with UMUI themes, see http://forums.winamp.com/showthread.php?p=3079742#post3079742
 		; shortcuts (&) for labels don't work and cause strange behaviour in NSIS - going to another page, etc.
 		${NSD_CreateLabel} 44u 30% 280u 16u "$0"
 		Pop $MultiUser.InstallModePage.AllUsersLabel
-		nsDialogs::SetUserData $MultiUser.InstallModePage.AllUsersLabel $MultiUser.InstallModePage.AllUsers						
+		nsDialogs::SetUserData $MultiUser.InstallModePage.AllUsersLabel $MultiUser.InstallModePage.AllUsers
 		${NSD_CreateLabel} 44u 45% 280u 8u "$1"
 		Pop $MultiUser.InstallModePage.CurrentUserLabel
-		nsDialogs::SetUserData $MultiUser.InstallModePage.CurrentUserLabel $MultiUser.InstallModePage.CurrentUser		
+		nsDialogs::SetUserData $MultiUser.InstallModePage.CurrentUserLabel $MultiUser.InstallModePage.CurrentUser
 
 		${if} $PerMachineOptionAvailable = 0 ; install per-machine is not available
 			SendMessage $MultiUser.InstallModePage.AllUsersLabel ${WM_SETTEXT} 0 "STR:$0$\r$\n($(MULTIUSER_RUN_AS_ADMIN))" ; only when $PerMachineOptionAvailable = 0, we add that comment to the disabled control itself
-			${orif} $CmdLineInstallMode != ""			
+			${orif} $CmdLineInstallMode != ""
 			EnableWindow $MultiUser.InstallModePage.AllUsersLabel 0 ; start out disabled
-			EnableWindow $MultiUser.InstallModePage.AllUsers 0 ; start out disabled			
+			EnableWindow $MultiUser.InstallModePage.AllUsers 0 ; start out disabled
 		${endif}
 
-		${if} $CmdLineInstallMode != ""		
-			EnableWindow $MultiUser.InstallModePage.CurrentUserLabel 0 
-			EnableWindow $MultiUser.InstallModePage.CurrentUser 0 
+		${if} $CmdLineInstallMode != ""
+			EnableWindow $MultiUser.InstallModePage.CurrentUserLabel 0
+			EnableWindow $MultiUser.InstallModePage.CurrentUser 0
 		${endif}
 
 		; bind to label click
 		${NSD_OnClick} $MultiUser.InstallModePage.CurrentUserLabel ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallModeOptionLabelClick
-		${NSD_OnClick} $MultiUser.InstallModePage.AllUsersLabel ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallModeOptionLabelClick		
+		${NSD_OnClick} $MultiUser.InstallModePage.AllUsersLabel ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallModeOptionLabelClick
 
 		; bind to radiobutton change
 		${NSD_OnClick} $MultiUser.InstallModePage.CurrentUser ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallModeOptionClick
 		${NSD_OnClick} $MultiUser.InstallModePage.AllUsers ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallModeOptionClick
-				
+
 		${NSD_CreateLabel} 0u -32u 100% 32u "" ; will hold up to 4 lines of text
 		Pop $MultiUser.InstallModePage.Description
 
 		${if} $MultiUser.InstallMode == "AllUsers" ; setting selected radio button
 			SendMessage $MultiUser.InstallModePage.AllUsers ${BM_SETCHECK} ${BST_CHECKED} 0 ; select radio button
 		${else}
-			SendMessage $MultiUser.InstallModePage.CurrentUser ${BM_SETCHECK} ${BST_CHECKED} 0 ; select radio button			
+			SendMessage $MultiUser.InstallModePage.CurrentUser ${BM_SETCHECK} ${BST_CHECKED} 0 ; select radio button
 		${endif}
 		Call ${UNINSTALLER_FUNCPREFIX}MultiUser.SetShieldAndTexts ; simulating click on the control will change $INSTDIR and reset a possible user selection
-		
+
 		!ifmacrodef UMUI_IOPAGEBGTRANSPARENT_INIT ; UMUI, apply theme to controls
 			!ifndef USE_MUIEx ; for MUIEx, applying themes causes artifacts
-				!insertmacro UMUI_IOPAGEBGTRANSPARENT_INIT $MultiUser.InstallModePage 
-				!insertmacro UMUI_IOPAGECTLTRANSPARENT_INIT $MultiUser.InstallModePage.Text 			
-				!insertmacro UMUI_IOPAGECTLTRANSPARENT_INIT $MultiUser.InstallModePage.AllUsers	
-				!insertmacro UMUI_IOPAGECTLTRANSPARENT_INIT $MultiUser.InstallModePage.AllUsersLabel 			
+				!insertmacro UMUI_IOPAGEBGTRANSPARENT_INIT $MultiUser.InstallModePage
+				!insertmacro UMUI_IOPAGECTLTRANSPARENT_INIT $MultiUser.InstallModePage.Text
+				!insertmacro UMUI_IOPAGECTLTRANSPARENT_INIT $MultiUser.InstallModePage.AllUsers
+				!insertmacro UMUI_IOPAGECTLTRANSPARENT_INIT $MultiUser.InstallModePage.AllUsersLabel
 				!insertmacro UMUI_IOPAGECTLTRANSPARENT_INIT $MultiUser.InstallModePage.CurrentUser
-				!insertmacro UMUI_IOPAGECTLTRANSPARENT_INIT $MultiUser.InstallModePage.CurrentUserLabel 
-				!insertmacro UMUI_IOPAGECTLTRANSPARENT_INIT $MultiUser.InstallModePage.Description			
-			!endif	
-		!endif	
+				!insertmacro UMUI_IOPAGECTLTRANSPARENT_INIT $MultiUser.InstallModePage.CurrentUserLabel
+				!insertmacro UMUI_IOPAGECTLTRANSPARENT_INIT $MultiUser.InstallModePage.Description
+			!endif
+		!endif
 
-		System::Store L 
-		
+		System::Store L
+
 		!ifdef MUI_PAGE_CUSTOMFUNCTION_SHOW
 			Call "${MUI_PAGE_CUSTOMFUNCTION_SHOW}"
 			!undef MUI_PAGE_CUSTOMFUNCTION_SHOW
-		!endif		
-		
-		nsDialogs::Show		
-		
+		!endif
+
+		nsDialogs::Show
+
 		!if "${UNINSTALLER_FUNCPREFIX}" == ""
 			Push $0
 			GetDlgItem $0 $HWNDPARENT 1
 			SendMessage $0 ${BCM_SETSHIELD} 0 0 ; hide SHIELD	on page leave (InstallModeLeave is called only on Next button click)
 			Pop $0
-		!endif		
+		!endif
 	FunctionEnd
 
 	Function ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallModeLeave
-		System::Store S 
-		
+		System::Store S
+
 		!if ${MULTIUSER_INSTALLMODE_ALLOW_ELEVATION} = 1 ; if elevation is allowed
 			Call ${UNINSTALLER_FUNCPREFIX}MultiUser.CheckPageElevationRequired
-			
+
 			${if} $0 = 1
 				HideWindow
 				!insertmacro UAC_RunElevated
 				;MessageBox MB_OK "[$0]/[$1]/[$2]/[$3]"
-				
+
 				; http://nsis.sourceforge.net/UAC_plug-in
 				${Switch} $0
 					${Case} 0
@@ -867,31 +867,31 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 										${Break}
 									${Default} ; all other cases - Quit
 										; return code of the elevated fork process is in $2 as well as set via SetErrorLevel
-										Quit 
+										Quit
 								${EndSwitch}
 								${Break}
 							${Case} 3 ; RunAs completed successfully, but with a non-admin user - stay on page
 								MessageBox MB_ICONSTOP "$(MULTIUSER_ADMIN_ACCOUNT_LOGIN_REQUIRED)" /SD IDOK
-								${Break}						
+								${Break}
 							${Default} ; 0 - UAC is not supported by the OS, OR 2 - The process is already running @ HighIL (Member of admin group) - stay on page
 								MessageBox MB_ICONSTOP "$(MULTIUSER_ELEVATION_NOT_SUPPORTED)" /SD IDOK
-						${EndSwitch}				
-						${Break}												
+						${EndSwitch}
+						${Break}
 					${Case} 1223 ; user aborted elevation dialog - stay on page
-						${Break} 
+						${Break}
 					${Case} 1062 ; Logon service not running - stay on page
 						MessageBox MB_ICONSTOP "$(MULTIUSER_LOGON_SERVICE_NOT_RUNNING)" /SD IDOK
 						${Break}
 					${Default} ; anything else should be treated as a fatal error - stay on page
 						${${UNINSTALLER_PREFIX}StrRep} "$0" "$(MULTIUSER_ELEVATION_ERROR)" "{ERROR}" "$0"
 						MessageBox MB_ICONSTOP "$0" /SD IDOK
-				${EndSwitch}				
+				${EndSwitch}
 
 				; clear the error level set by UAC for inner instance, so that outer instance returns its own error level when exits (the error level is not reset by NSIS if once set and >= 0)
 				; see http://forums.winamp.com/showthread.php?p=3079116&posted=1#post3079116
 				SetErrorLevel -1
 				BringToFront
-				Abort ; Stay on page 			
+				Abort ; Stay on page
 			${endif}
 		!endif
 
@@ -905,28 +905,23 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 
 	Function ${UNINSTALLER_FUNCPREFIX}MultiUser.SetShieldAndTexts
 		System::Store S
-		
-		GetDlgItem $1 $hwndParent 1 ; get item 1 (next button) at parent window, store in $1 - (0 is back, 1 is next .. what about CANCEL? http://nsis.sourceforge.net/Buttons_Header )
 
-		Call ${UNINSTALLER_FUNCPREFIX}MultiUser.CheckPageElevationRequired
-		SendMessage $1 ${BCM_SETSHIELD} 0 $0 ; display/hide SHIELD (Windows Vista and above)
-				
 		StrCpy $0 "$MultiUser.InstallMode"
 		; if necessary, display text for different install mode rather than the actual one in $MultiUser.InstallMode
 		!if ${MULTIUSER_INSTALLMODE_ALLOW_BOTH_INSTALLATIONS} = 0
-			!if "${UNINSTALLER_FUNCPREFIX}" == ""			
-				${if} $MultiUser.InstallMode == "AllUsers" ; user selected "all users" 
+			!if "${UNINSTALLER_FUNCPREFIX}" == ""
+				${if} $MultiUser.InstallMode == "AllUsers" ; user selected "all users"
 					${if} $HasPerMachineInstallation = 0
 						${andif} $HasPerUserInstallation = 1
 						StrCpy $0 "CurrentUser" ; display information for the "current user" installation
-					${endif}	
+					${endif}
 				${elseif} $HasPerMachineInstallation = 1
 					${andif} $HasPerUserInstallation = 0 ; user selected "current user"
 					StrCpy $0 "AllUsers" ; display information for the "all users" installation
 				${endif}
 			!endif
-		!endif				
-			
+		!endif
+
 		; set label text
 		StrCpy $1 ""
 		${if} $0 == "AllUsers" ; all users
@@ -938,43 +933,40 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 					${if} $PerMachineInstallationVersion == "${VERSION}"
 						${if} $MultiUser.InstallMode == "AllUsers"
 							${${UNINSTALLER_PREFIX}StrRep} "$2" "$(MULTIUSER_REINSTALL_SAME_VERSION_ALL_USERS)" "{VERSION}" "$PerMachineInstallationVersion"
-						${else}	
+						${else}
 							${${UNINSTALLER_PREFIX}StrRep} "$2" "$(MULTIUSER_REINSTALL_SAME_VERSION_CURRENT_USER)" "{VERSION}" "$PerMachineInstallationVersion"
-						${endif}					
+						${endif}
 					${else}
 						${if} $MultiUser.InstallMode == "AllUsers"
 							${${UNINSTALLER_PREFIX}StrRep} "$2" "$(MULTIUSER_REINSTALL_DIFF_VERSION_ALL_USERS)" "{OLD_VERSION}" "$PerMachineInstallationVersion"
 							${${UNINSTALLER_PREFIX}StrRep} "$2" "$2" "{VERSION}" "${VERSION}"
-						${else}	
+						${else}
 							${${UNINSTALLER_PREFIX}StrRep} "$2" "$(MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER)" "{OLD_VERSION}" "$PerMachineInstallationVersion"
 							${${UNINSTALLER_PREFIX}StrRep} "$2" "$2" "{VERSION}" "${VERSION}"
 						${endif}
-					${endif}	
+					${endif}
 					StrCpy $1 "$1$\r$\n$2"
 				!endif
 			${else}
 				StrCpy $1 "$(MULTIUSER_NEW_INSTALLATION_ALL_USERS)"
 			${endif}
-			${if} $IsAdmin = 0
-				StrCpy $1 "$1 $(MULTIUSER_ADMIN_CREDENTIALS_REQUIRED)"
-			${endif}		
 		${else} ; current user
 			${if} $HasPerUserInstallation = 1
 				${${UNINSTALLER_PREFIX}StrRep} "$1" "$(MULTIUSER_INSTALLED_CURRENT_USER)" "{VERSION}" "$PerUserInstallationVersion"
 				${${UNINSTALLER_PREFIX}StrRep} "$1" "$1" "{FOLDER}" "$PerUserInstallationFolder"
-			
+
 				!if "${UNINSTALLER_FUNCPREFIX}" == ""
 					${if} $PerUserInstallationVersion == "${VERSION}"
 						${if} $MultiUser.InstallMode == "AllUsers"
 							${${UNINSTALLER_PREFIX}StrRep} "$2" "$(MULTIUSER_REINSTALL_SAME_VERSION_ALL_USERS)" "{VERSION}" "$PerUserInstallationVersion"
-						${else}	
+						${else}
 							${${UNINSTALLER_PREFIX}StrRep} "$2" "$(MULTIUSER_REINSTALL_SAME_VERSION_CURRENT_USER)" "{VERSION}" "$PerUserInstallationVersion"
-						${endif}					
+						${endif}
 					${else}
 						${if} $MultiUser.InstallMode == "AllUsers"
 							${${UNINSTALLER_PREFIX}StrRep} "$2" "$(MULTIUSER_REINSTALL_DIFF_VERSION_ALL_USERS)" "{OLD_VERSION}" "$PerUserInstallationVersion"
 							${${UNINSTALLER_PREFIX}StrRep} "$2" "$2" "{VERSION}" "${VERSION}"
-						${else}	
+						${else}
 							${${UNINSTALLER_PREFIX}StrRep} "$2" "$(MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER)" "{OLD_VERSION}" "$PerUserInstallationVersion"
 							${${UNINSTALLER_PREFIX}StrRep} "$2" "$2" "{VERSION}" "${VERSION}"
 						${endif}
@@ -983,11 +975,20 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 				!endif
 			${else}
 				StrCpy $1 "$(MULTIUSER_NEW_INSTALLATION_CURRENT_USER)"
-			${endif}		
+			${endif}
 		${endif}
-		
+
+		Call ${UNINSTALLER_FUNCPREFIX}MultiUser.CheckPageElevationRequired
+		${if} $0 = 1
+			StrCpy $1 "$1 $(MULTIUSER_ADMIN_CREDENTIALS_REQUIRED)"
+		${endif}
+
 		SendMessage $MultiUser.InstallModePage.Description ${WM_SETTEXT} 0 "STR:$1"
-		
+
+		GetDlgItem $1 $hwndParent 1 ; get item 1 (next button) at parent window, store in $1 - (0 is back, 1 is next .. what about CANCEL? http://nsis.sourceforge.net/Buttons_Header )
+
+		SendMessage $1 ${BCM_SETSHIELD} 0 $0 ; display/hide SHIELD (Windows Vista and above)
+
 		System::Store L
 	FunctionEnd
 
@@ -996,15 +997,15 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 		nsDialogs::GetUserData $0
 		Pop $0
 
-		${NSD_Uncheck} $MultiUser.InstallModePage.AllUsers 
+		${NSD_Uncheck} $MultiUser.InstallModePage.AllUsers
 		${NSD_Uncheck} $MultiUser.InstallModePage.CurrentUser
 		${NSD_Check} $0 ; ${NSD_Check} will check both radio buttons without the above 2 lines
-		${NSD_SetFocus} $0		
+		${NSD_SetFocus} $0
 		Push $0
 		; ${NSD_Check} doesn't call Click event
 		Call ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallModeOptionClick
-		
-		Pop $0		
+
+		Pop $0
 	FunctionEnd
 
 	Function ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallModeOptionClick
@@ -1013,24 +1014,24 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 		; set InstallMode
 		${if} $0 = $MultiUser.InstallModePage.AllUsers
 			Call ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallMode.AllUsers
-		${else}	
+		${else}
 			Call ${UNINSTALLER_FUNCPREFIX}MultiUser.InstallMode.CurrentUser
-		${endif}				
+		${endif}
 
 		Call ${UNINSTALLER_FUNCPREFIX}MultiUser.SetShieldAndTexts
-		
+
 		Pop $0
-	FunctionEnd	
+	FunctionEnd
 !macroend
 
 !macro MULTIUSER_GetCurrentUserString VAR
 	StrCpy ${VAR} ""
 	!if ${MULTIUSER_INSTALLMODE_ALLOW_BOTH_INSTALLATIONS} <> 0
-		${if} $MultiUser.InstallMode == "CurrentUser" 
+		${if} $MultiUser.InstallMode == "CurrentUser"
 			${orif} $MultiUser.InstallMode == "" ; called from InitChecks
 			StrCpy ${VAR} " (current user)"
 		${endif}
-	!endif				
+	!endif
 !macroend
 
 !macro MULTIUSER_RegistryAddInstallInfo
@@ -1044,20 +1045,20 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 	; this will create 2 different keys in HKCU (MULTIUSER_INSTALLMODE_INSTALL_REGISTRY_KEY_PATH and MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH),
 	; but that's OK, both will be removed by uninstaller
 	!insertmacro MULTIUSER_GetCurrentUserString $0
-	
+
 	${if} $MultiUser.InstallMode == "AllUsers" ; setting defaults
 		WriteRegStr SHCTX "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}" "DisplayName" "${MULTIUSER_INSTALLMODE_DISPLAYNAME}"
-		WriteRegStr SHCTX "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}" "UninstallString" '"$INSTDIR\${UNINSTALL_FILENAME}" /allusers' 
+		WriteRegStr SHCTX "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}" "UninstallString" '"$INSTDIR\${UNINSTALL_FILENAME}" /allusers'
 	${else}
 		WriteRegStr SHCTX "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}$0" "DisplayName" "${MULTIUSER_INSTALLMODE_DISPLAYNAME} (current user)" ; "add/remove programs" will show if installation is per-user
-		WriteRegStr SHCTX "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}$0" "UninstallString" '"$INSTDIR\${UNINSTALL_FILENAME}" /currentuser' 
+		WriteRegStr SHCTX "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}$0" "UninstallString" '"$INSTDIR\${UNINSTALL_FILENAME}" /currentuser'
 	${endif}
 
 	WriteRegStr SHCTX "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}$0" "DisplayVersion" "${VERSION}"
 	WriteRegStr SHCTX "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}$0" "DisplayIcon" "$INSTDIR\${PROGEXE},0"
 	!ifdef COMPANY_NAME
 		WriteRegStr SHCTX "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}$0" "Publisher" "${COMPANY_NAME}"
-	!endif	
+	!endif
 	WriteRegDWORD SHCTX "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}$0" "NoModify" 1
 	WriteRegDWORD SHCTX "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}$0" "NoRepair" 1
 
@@ -1075,7 +1076,7 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 	${GetSize} "$INSTDIR" "/S=0K" $1 $2 $3 ; get folder size, convert to KB
 	IntFmt $1 "0x%08X" $1
 	WriteRegDWORD SHCTX "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}$0" "EstimatedSize" "$1"
-	
+
 	Pop $3
 	Pop $2
 	Pop $1
@@ -1088,11 +1089,11 @@ RequestExecutionLevel user ; will ask elevation only if necessary
 	; Remove registry keys
 	DeleteRegKey SHCTX "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}"
 	!insertmacro MULTIUSER_GetCurrentUserString $0
-	${if} "$0" != ""	
+	${if} "$0" != ""
 		DeleteRegKey SHCTX "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}$0"
-	${endif}	
+	${endif}
 	DeleteRegKey SHCTX "${MULTIUSER_INSTALLMODE_INSTALL_REGISTRY_KEY_PATH}"
- 
+
 	Pop $0
 !macroend
 

--- a/Include/NsisMultiUserLang.nsh
+++ b/Include/NsisMultiUserLang.nsh
@@ -16,6 +16,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_ENGLISH} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_ENGLISH} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_ENGLISH} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_ENGLISH} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_ENGLISH} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_ENGLISH} "There is no installation of $(^NameDA)."
@@ -44,6 +45,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_AFRIKAANS} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_AFRIKAANS} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_AFRIKAANS} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_AFRIKAANS} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_AFRIKAANS} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_AFRIKAANS} "There is no installation of $(^NameDA)."
@@ -72,6 +74,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_ALBANIAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_ALBANIAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_ALBANIAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_ALBANIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_ALBANIAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_ALBANIAN} "There is no installation of $(^NameDA)."
@@ -100,6 +103,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_ARABIC} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_ARABIC} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_ARABIC} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_ARABIC} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_ARABIC} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_ARABIC} "There is no installation of $(^NameDA)."
@@ -128,6 +132,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_ARMENIAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_ARMENIAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_ARMENIAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_ARMENIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_ARMENIAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_ARMENIAN} "There is no installation of $(^NameDA)."
@@ -156,6 +161,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_ASTURIAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_ASTURIAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_ASTURIAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_ASTURIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_ASTURIAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_ASTURIAN} "There is no installation of $(^NameDA)."
@@ -184,6 +190,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_BASQUE} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_BASQUE} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_BASQUE} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_BASQUE} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_BASQUE} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_BASQUE} "There is no installation of $(^NameDA)."
@@ -212,6 +219,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_BELARUSIAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_BELARUSIAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_BELARUSIAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_BELARUSIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_BELARUSIAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_BELARUSIAN} "There is no installation of $(^NameDA)."
@@ -240,6 +248,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_BOSNIAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_BOSNIAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_BOSNIAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_BOSNIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_BOSNIAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_BOSNIAN} "There is no installation of $(^NameDA)."
@@ -268,6 +277,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_BRETON} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_BRETON} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_BRETON} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_BRETON} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_BRETON} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_BRETON} "There is no installation of $(^NameDA)."
@@ -296,6 +306,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_BULGARIAN} "Деинсталиране на версия {OLD_VERSION} и инсталиране на версия {VERSION} за текущия потребител."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_BULGARIAN} "Трябва да стартирате тази програма като администратор."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_BULGARIAN} "Изисква се администраторска идентификация."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_BULGARIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_BULGARIAN} "Невалидна комбинация от параметри."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_BULGARIAN} "Няма инсталация на $(^NameDA)."
@@ -324,6 +335,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_CATALAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_CATALAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_CATALAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_CATALAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_CATALAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_CATALAN} "There is no installation of $(^NameDA)."
@@ -352,6 +364,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_CORSICAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_CORSICAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_CORSICAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_CORSICAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_CORSICAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_CORSICAN} "There is no installation of $(^NameDA)."
@@ -380,6 +393,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_CROATIAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_CROATIAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_CROATIAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_CROATIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_CROATIAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_CROATIAN} "There is no installation of $(^NameDA)."
@@ -408,6 +422,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_CZECH} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_CZECH} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_CZECH} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_CZECH} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_CZECH} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_CZECH} "There is no installation of $(^NameDA)."
@@ -436,6 +451,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_DANISH} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_DANISH} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_DANISH} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_DANISH} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_DANISH} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_DANISH} "There is no installation of $(^NameDA)."
@@ -464,6 +480,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_DUTCH} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_DUTCH} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_DUTCH} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_DUTCH} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_DUTCH} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_DUTCH} "There is no installation of $(^NameDA)."
@@ -492,6 +509,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_ESPERANTO} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_ESPERANTO} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_ESPERANTO} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_ESPERANTO} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_ESPERANTO} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_ESPERANTO} "There is no installation of $(^NameDA)."
@@ -520,6 +538,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_ESTONIAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_ESTONIAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_ESTONIAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_ESTONIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_ESTONIAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_ESTONIAN} "There is no installation of $(^NameDA)."
@@ -548,6 +567,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_FARSI} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_FARSI} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_FARSI} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_FARSI} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_FARSI} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_FARSI} "There is no installation of $(^NameDA)."
@@ -576,6 +596,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_FINNISH} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_FINNISH} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_FINNISH} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_FINNISH} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_FINNISH} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_FINNISH} "There is no installation of $(^NameDA)."
@@ -604,6 +625,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_FRENCH} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_FRENCH} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_FRENCH} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_FRENCH} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_FRENCH} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_FRENCH} "There is no installation of $(^NameDA)."
@@ -632,6 +654,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_GALICIAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_GALICIAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_GALICIAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_GALICIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_GALICIAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_GALICIAN} "There is no installation of $(^NameDA)."
@@ -660,6 +683,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_GEORGIAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_GEORGIAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_GEORGIAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_GEORGIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_GEORGIAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_GEORGIAN} "There is no installation of $(^NameDA)."
@@ -688,6 +712,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_GERMAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_GERMAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_GERMAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_GERMAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_GERMAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_GERMAN} "There is no installation of $(^NameDA)."
@@ -716,6 +741,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_GREEK} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_GREEK} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_GREEK} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_GREEK} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_GREEK} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_GREEK} "There is no installation of $(^NameDA)."
@@ -744,6 +770,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_HEBREW} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_HEBREW} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_HEBREW} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_HEBREW} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_HEBREW} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_HEBREW} "There is no installation of $(^NameDA)."
@@ -772,6 +799,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_HUNGARIAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_HUNGARIAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_HUNGARIAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_HUNGARIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_HUNGARIAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_HUNGARIAN} "There is no installation of $(^NameDA)."
@@ -800,6 +828,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_ICELANDIC} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_ICELANDIC} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_ICELANDIC} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_ICELANDIC} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_ICELANDIC} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_ICELANDIC} "There is no installation of $(^NameDA)."
@@ -828,6 +857,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_INDONESIAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_INDONESIAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_INDONESIAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_INDONESIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_INDONESIAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_INDONESIAN} "There is no installation of $(^NameDA)."
@@ -856,6 +886,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_IRISH} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_IRISH} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_IRISH} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_IRISH} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_IRISH} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_IRISH} "There is no installation of $(^NameDA)."
@@ -884,6 +915,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_ITALIAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_ITALIAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_ITALIAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_ITALIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_ITALIAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_ITALIAN} "There is no installation of $(^NameDA)."
@@ -912,6 +944,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_JAPANESE} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_JAPANESE} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_JAPANESE} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_JAPANESE} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_JAPANESE} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_JAPANESE} "There is no installation of $(^NameDA)."
@@ -940,6 +973,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_KOREAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_KOREAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_KOREAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_KOREAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_KOREAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_KOREAN} "There is no installation of $(^NameDA)."
@@ -968,6 +1002,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_KURDISH} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_KURDISH} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_KURDISH} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_KURDISH} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_KURDISH} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_KURDISH} "There is no installation of $(^NameDA)."
@@ -996,6 +1031,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_LATVIAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_LATVIAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_LATVIAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_LATVIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_LATVIAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_LATVIAN} "There is no installation of $(^NameDA)."
@@ -1024,6 +1060,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_LITHUANIAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_LITHUANIAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_LITHUANIAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_LITHUANIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_LITHUANIAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_LITHUANIAN} "There is no installation of $(^NameDA)."
@@ -1052,6 +1089,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_LUXEMBOURGISH} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_LUXEMBOURGISH} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_LUXEMBOURGISH} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_LUXEMBOURGISH} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_LUXEMBOURGISH} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_LUXEMBOURGISH} "There is no installation of $(^NameDA)."
@@ -1080,6 +1118,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_MACEDONIAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_MACEDONIAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_MACEDONIAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_MACEDONIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_MACEDONIAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_MACEDONIAN} "There is no installation of $(^NameDA)."
@@ -1108,6 +1147,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_MALAY} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_MALAY} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_MALAY} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_MALAY} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_MALAY} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_MALAY} "There is no installation of $(^NameDA)."
@@ -1136,6 +1176,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_MONGOLIAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_MONGOLIAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_MONGOLIAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_MONGOLIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_MONGOLIAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_MONGOLIAN} "There is no installation of $(^NameDA)."
@@ -1164,6 +1205,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_NORWEGIAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_NORWEGIAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_NORWEGIAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_NORWEGIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_NORWEGIAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_NORWEGIAN} "There is no installation of $(^NameDA)."
@@ -1192,6 +1234,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_NORWEGIANNYNORSK} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_NORWEGIANNYNORSK} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_NORWEGIANNYNORSK} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_NORWEGIANNYNORSK} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_NORWEGIANNYNORSK} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_NORWEGIANNYNORSK} "There is no installation of $(^NameDA)."
@@ -1220,6 +1263,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_PASHTO} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_PASHTO} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_PASHTO} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_PASHTO} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_PASHTO} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_PASHTO} "There is no installation of $(^NameDA)."
@@ -1248,6 +1292,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_POLISH} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_POLISH} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_POLISH} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_POLISH} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_POLISH} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_POLISH} "There is no installation of $(^NameDA)."
@@ -1276,6 +1321,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_PORTUGUESE} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_PORTUGUESE} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_PORTUGUESE} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_PORTUGUESE} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_PORTUGUESE} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_PORTUGUESE} "There is no installation of $(^NameDA)."
@@ -1304,6 +1350,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_PORTUGUESEBR} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_PORTUGUESEBR} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_PORTUGUESEBR} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_PORTUGUESEBR} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_PORTUGUESEBR} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_PORTUGUESEBR} "There is no installation of $(^NameDA)."
@@ -1332,6 +1379,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_ROMANIAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_ROMANIAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_ROMANIAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_ROMANIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_ROMANIAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_ROMANIAN} "There is no installation of $(^NameDA)."
@@ -1360,6 +1408,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_RUSSIAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_RUSSIAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_RUSSIAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_RUSSIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_RUSSIAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_RUSSIAN} "There is no installation of $(^NameDA)."
@@ -1388,6 +1437,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_SCOTSGAELIC} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_SCOTSGAELIC} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_SCOTSGAELIC} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_SCOTSGAELIC} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_SCOTSGAELIC} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_SCOTSGAELIC} "There is no installation of $(^NameDA)."
@@ -1416,6 +1466,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_SERBIAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_SERBIAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_SERBIAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_SERBIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_SERBIAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_SERBIAN} "There is no installation of $(^NameDA)."
@@ -1444,6 +1495,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_SERBIANLATIN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_SERBIANLATIN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_SERBIANLATIN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_SERBIANLATIN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_SERBIANLATIN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_SERBIANLATIN} "There is no installation of $(^NameDA)."
@@ -1472,6 +1524,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_SIMPCHINESE} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_SIMPCHINESE} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_SIMPCHINESE} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_SIMPCHINESE} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_SIMPCHINESE} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_SIMPCHINESE} "There is no installation of $(^NameDA)."
@@ -1500,6 +1553,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_SLOVAK} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_SLOVAK} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_SLOVAK} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_SLOVAK} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_SLOVAK} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_SLOVAK} "There is no installation of $(^NameDA)."
@@ -1528,6 +1582,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_SLOVENIAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_SLOVENIAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_SLOVENIAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_SLOVENIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_SLOVENIAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_SLOVENIAN} "There is no installation of $(^NameDA)."
@@ -1556,6 +1611,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_SPANISH} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_SPANISH} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_SPANISH} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_SPANISH} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_SPANISH} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_SPANISH} "There is no installation of $(^NameDA)."
@@ -1584,6 +1640,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_SPANISHINTERNATIONAL} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_SPANISHINTERNATIONAL} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_SPANISHINTERNATIONAL} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_SPANISHINTERNATIONAL} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_SPANISHINTERNATIONAL} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_SPANISHINTERNATIONAL} "There is no installation of $(^NameDA)."
@@ -1612,6 +1669,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_SWEDISH} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_SWEDISH} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_SWEDISH} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_SWEDISH} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_SWEDISH} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_SWEDISH} "There is no installation of $(^NameDA)."
@@ -1640,6 +1698,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_TATAR} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_TATAR} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_TATAR} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_TATAR} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_TATAR} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_TATAR} "There is no installation of $(^NameDA)."
@@ -1668,6 +1727,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_THAI} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_THAI} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_THAI} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_THAI} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_THAI} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_THAI} "There is no installation of $(^NameDA)."
@@ -1696,6 +1756,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_TRADCHINESE} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_TRADCHINESE} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_TRADCHINESE} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_TRADCHINESE} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_TRADCHINESE} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_TRADCHINESE} "There is no installation of $(^NameDA)."
@@ -1724,6 +1785,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_TURKISH} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_TURKISH} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_TURKISH} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_TURKISH} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_TURKISH} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_TURKISH} "There is no installation of $(^NameDA)."
@@ -1752,6 +1814,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_UKRAINIAN} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_UKRAINIAN} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_UKRAINIAN} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_UKRAINIAN} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_UKRAINIAN} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_UKRAINIAN} "There is no installation of $(^NameDA)."
@@ -1780,6 +1843,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_UZBEK} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_UZBEK} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_UZBEK} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_UZBEK} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_UZBEK} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_UZBEK} "There is no installation of $(^NameDA)."
@@ -1808,6 +1872,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_VIETNAMESE} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_VIETNAMESE} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_VIETNAMESE} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_VIETNAMESE} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_VIETNAMESE} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_VIETNAMESE} "There is no installation of $(^NameDA)."
@@ -1836,6 +1901,7 @@
 	LangString MULTIUSER_REINSTALL_DIFF_VERSION_CURRENT_USER ${LANG_WELSH} "Uninstall version {OLD_VERSION} and install version {VERSION} for current user."
 	LangString MULTIUSER_RUN_AS_ADMIN ${LANG_WELSH} "You need to run this program as administrator."
 	LangString MULTIUSER_ADMIN_CREDENTIALS_REQUIRED ${LANG_WELSH} "Administrator credentials required."
+	LangString MULTIUSER_ADMIN_UNINSTALL_CREDENTIALS_REQUIRED ${LANG_WELSH} "Administrator credentials required for uninstall."
 	; error messages - not so important
 	LangString MULTIUSER_INVALID_PARAMS ${LANG_WELSH} "Invalid combination of paramaters."
 	LangString MULTIUSER_NOT_INSTALLED ${LANG_WELSH} "There is no installation of $(^NameDA)."


### PR DESCRIPTION
Fixes #15:

- If a standard user changes an all-users installation to current-user (using an admin account for elevation), the installation is performed for the admin user.
- If a standard user changes a current-user installation to all-users (using an admin account for elevation, MULTIUSER_INSTALLMODE_ALLOW_BOTH_INSTALLATIONS is 0), the current-user installation is not removed (the uninstaller is running for admin). Also the elevation requirement text is not displayed.
