### PR TITLE
Workaround for Windows uninstaller elevation bug

### DIFF
--- a/Demos/MUI2_Limited/Uninstall.nsh
+++ b/Demos/MUI2_Limited/Uninstall.nsh
@@ -2,6 +2,7 @@
 
 ; Variables
 Var RunningFromInstaller ; installer started uninstaller using /uninstall parameter
+Var RunningAsShellUser ; uninstaller restarted itself under the user of the running shell
 
 Section "un.Program Files" SectionUninstallProgram
 	SectionIn RO
@@ -73,8 +74,28 @@ Function un.onInit
 		StrCpy $RunningFromInstaller 0
 	${endif}
 
+	${GetOptions} $R0 "/shelluser" $R1
+	${ifnot} ${errors}
+		StrCpy $RunningAsShellUser 1
+	${else}
+		StrCpy $RunningAsShellUser 0
+	${endif}
+
 	${ifnot} ${UAC_IsInnerInstance}
-		${andif} $RunningFromInstaller = 0
+	${andif} $RunningFromInstaller = 0
+		; Restarting the uninstaller using the user of the running shell, in order to overcome the Windows bugs that:
+		; - Elevates the uninstallers of single-user installations when called from 'Apps & features' of Windows 10
+		; causing them to fail when using a different account for elevation.
+		; - Elevates the uninstallers of all-users installations when called from 'Add/Remove Programs' of Control Panel,
+		; preventing them of eleveting on their own and correctly recognize the user that started the uninstaller. If a
+		; different account was used for elevation, all user-context operations will be performed for the user of that
+		; account. In this case, the fix causes the elevetion prompt to be displayed twice (one from Control Panel and
+		; one from the uninstaller).
+		${if} ${UAC_IsAdmin}
+		${andif} $RunningAsShellUser = 0
+			${StdUtils.ExecShellAsUser} $0 "$INSTDIR\${UNINSTALL_FILENAME}" "open" "/user $R0"
+			Quit
+		${endif}
 		!insertmacro CheckSingleInstance "Setup" "Global" "${SETUP_MUTEX}"
 		!insertmacro CheckSingleInstance "Application" "Local" "${APP_MUTEX}"
 	${endif}

--- a/Demos/NSIS_Full/Uninstall.nsh
+++ b/Demos/NSIS_Full/Uninstall.nsh
@@ -3,6 +3,7 @@
 ; Variables
 Var SemiSilentMode ; installer started uninstaller in semi-silent mode using /SS parameter
 Var RunningFromInstaller ; installer started uninstaller using /uninstall parameter
+Var RunningAsShellUser ; uninstaller restarted itself under the user of the running shell
 
 Section "un.Program Files" SectionUninstallProgram
 	SectionIn RO
@@ -80,8 +81,28 @@ Function un.onInit
 		StrCpy $SemiSilentMode 0
 	${endif}
 
+	${GetOptions} $R0 "/shelluser" $R1
+	${ifnot} ${errors}
+		StrCpy $RunningAsShellUser 1
+	${else}
+		StrCpy $RunningAsShellUser 0
+	${endif}
+
 	${ifnot} ${UAC_IsInnerInstance}
-		${andif} $RunningFromInstaller = 0
+	${andif} $RunningFromInstaller = 0
+		; Restarting the uninstaller using the user of the running shell, in order to overcome the Windows bugs that:
+		; - Elevates the uninstallers of single-user installations when called from 'Apps & features' of Windows 10
+		; causing them to fail when using a different account for elevation.
+		; - Elevates the uninstallers of all-users installations when called from 'Add/Remove Programs' of Control Panel,
+		; preventing them of eleveting on their own and correctly recognize the user that started the uninstaller. If a
+		; different account was used for elevation, all user-context operations will be performed for the user of that
+		; account. In this case, the fix causes the elevetion prompt to be displayed twice (one from Control Panel and
+		; one from the uninstaller).
+		${if} ${UAC_IsAdmin}
+		${andif} $RunningAsShellUser = 0
+			${StdUtils.ExecShellAsUser} $0 "$INSTDIR\${UNINSTALL_FILENAME}" "open" "/user $R0"
+			Quit
+		${endif}
 		!insertmacro CheckSingleInstance "Setup" "Global" "${SETUP_MUTEX}"
 		!insertmacro CheckSingleInstance "Application" "Local" "${APP_MUTEX}"
 	${endif}

--- a/Demos/UMUI_Ex_Full/Uninstall.nsh
+++ b/Demos/UMUI_Ex_Full/Uninstall.nsh
@@ -3,6 +3,7 @@
 ; Variables
 Var SemiSilentMode ; installer started uninstaller in semi-silent mode using /SS parameter
 Var RunningFromInstaller ; installer started uninstaller using /uninstall parameter
+Var RunningAsShellUser ; uninstaller restarted itself under the user of the running shell
 
 Section "un.Program Files" SectionUninstallProgram
 	SectionIn RO
@@ -93,6 +94,32 @@ Function un.onInit
 		SetAutoClose true ; auto close (if no errors) if we are called from the installer; if there are errors, will be automatically set to false
 	${else}
 		StrCpy $SemiSilentMode 0
+	${endif}
+
+	${GetOptions} $R0 "/shelluser" $R1
+	${ifnot} ${errors}
+		StrCpy $RunningAsShellUser 1
+	${else}
+		StrCpy $RunningAsShellUser 0
+	${endif}
+
+	${ifnot} ${UAC_IsInnerInstance}
+	${andif} $RunningFromInstaller = 0
+		; Restarting the uninstaller using the user of the running shell, in order to overcome the Windows bugs that:
+		; - Elevates the uninstallers of single-user installations when called from 'Apps & features' of Windows 10
+		; causing them to fail when using a different account for elevation.
+		; - Elevates the uninstallers of all-users installations when called from 'Add/Remove Programs' of Control Panel,
+		; preventing them of eleveting on their own and correctly recognize the user that started the uninstaller. If a
+		; different account was used for elevation, all user-context operations will be performed for the user of that
+		; account. In this case, the fix causes the elevetion prompt to be displayed twice (one from Control Panel and
+		; one from the uninstaller).
+		${if} ${UAC_IsAdmin}
+		${andif} $RunningAsShellUser = 0
+			${StdUtils.ExecShellAsUser} $0 "$INSTDIR\${UNINSTALL_FILENAME}" "open" "/user $R0"
+			Quit
+		${endif}
+		!insertmacro CheckSingleInstance "Setup" "Global" "${SETUP_MUTEX}"
+		!insertmacro CheckSingleInstance "Application" "Local" "${APP_MUTEX}"
 	${endif}
 
 	${ifnot} ${UAC_IsInnerInstance}


### PR DESCRIPTION
When the uninstaller is started as administrator but not from the
installer, it restarts itself under the user of the running shell,
in order to overcome the Windows bugs that:
- Elevates the uninstallers of single-user installations when
called from 'Apps & features' of Windows 10 causing them to fail
when using a different account for elevation.
- Elevates the uninstallers of all-users installations when called
from 'Add/Remove Programs' of Control Panel, preventing them of
eleveting on their own and correctly recognize the user that started
the uninstaller. If a different account was used for elevation, all
user-context operations will be performed for the user of that
account. In this case, the fix causes the elevetion prompt to be
displayed twice (one from Control Panel and one from the uninstaller).
Closes #6