### PR TITLE
Adding some notes to the files for version management of downstream…

### DIFF
--- a/Demos/Common/Utils.nsh
+++ b/Demos/Common/Utils.nsh
@@ -1,3 +1,16 @@
+/*
+
+NsisMultiUser.nsh - NSIS plugin that allows "per-user" (no admin required) and "per-machine" (asks elevation *only when necessary*) installations
+
+Full source code, documentation and demos at https://github.com/Drizin/NsisMultiUser/
+
+Copyright 2016-2019 Ricardo Drizin, Alex Mitev
+
+File   : Demos\Common\Utils.nsh
+Version: 2019-05-06
+
+*/
+
 !include LogicLib.nsh
 !include x64.nsh
 

--- a/Demos/MUI2_Limited/Setup.nsi
+++ b/Demos/MUI2_Limited/Setup.nsi
@@ -1,3 +1,16 @@
+/*
+
+NsisMultiUser.nsh - NSIS plugin that allows "per-user" (no admin required) and "per-machine" (asks elevation *only when necessary*) installations
+
+Full source code, documentation and demos at https://github.com/Drizin/NsisMultiUser/
+
+Copyright 2016-2019 Ricardo Drizin, Alex Mitev
+
+File   : Demos\MUI2_Limited\Setup.nsi
+Version: 2019-07-24
+
+*/
+
 !addplugindir /x86-ansi ".\..\..\Plugins\x86-ansi"
 !addplugindir /x86-unicode ".\..\..\Plugins\x86-unicode"
 !addincludedir ".\..\..\Include"

--- a/Demos/MUI2_Limited/Uninstall.nsh
+++ b/Demos/MUI2_Limited/Uninstall.nsh
@@ -1,3 +1,16 @@
+/*
+
+NsisMultiUser.nsh - NSIS plugin that allows "per-user" (no admin required) and "per-machine" (asks elevation *only when necessary*) installations
+
+Full source code, documentation and demos at https://github.com/Drizin/NsisMultiUser/
+
+Copyright 2016-2019 Ricardo Drizin, Alex Mitev
+
+File   : Demos\MUI2_Limited\Uninstall.nsh
+Version: 2019-07-24
+
+*/
+
 !include un.Utils.nsh
 
 ; Variables

--- a/Demos/MUI_1_2_Full/Setup.nsi
+++ b/Demos/MUI_1_2_Full/Setup.nsi
@@ -1,3 +1,16 @@
+/*
+
+NsisMultiUser.nsh - NSIS plugin that allows "per-user" (no admin required) and "per-machine" (asks elevation *only when necessary*) installations
+
+Full source code, documentation and demos at https://github.com/Drizin/NsisMultiUser/
+
+Copyright 2016-2019 Ricardo Drizin, Alex Mitev
+
+File   : Demos\MUI_1_2_Full\Setup.nsi
+Version: 2019-07-24
+
+*/
+
 !addplugindir /x86-ansi ".\..\..\Plugins\x86-ansi"
 !addplugindir /x86-unicode ".\..\..\Plugins\x86-unicode"
 !addincludedir ".\..\..\Include"

--- a/Demos/MUI_1_2_Full/Uninstall.nsh
+++ b/Demos/MUI_1_2_Full/Uninstall.nsh
@@ -1,3 +1,16 @@
+/*
+
+NsisMultiUser.nsh - NSIS plugin that allows "per-user" (no admin required) and "per-machine" (asks elevation *only when necessary*) installations
+
+Full source code, documentation and demos at https://github.com/Drizin/NsisMultiUser/
+
+Copyright 2016-2019 Ricardo Drizin, Alex Mitev
+
+File   : Demos\MUI_1_2_Full\Uninstall.nsh
+Version: 2019-07-24
+
+*/
+
 !include un.Utils.nsh
 
 ; Variables

--- a/Demos/NSIS_Full/Setup.nsi
+++ b/Demos/NSIS_Full/Setup.nsi
@@ -1,3 +1,16 @@
+/*
+
+NsisMultiUser.nsh - NSIS plugin that allows "per-user" (no admin required) and "per-machine" (asks elevation *only when necessary*) installations
+
+Full source code, documentation and demos at https://github.com/Drizin/NsisMultiUser/
+
+Copyright 2016-2019 Ricardo Drizin, Alex Mitev
+
+File   : Demos\NSIS_Full\Setup.nsi
+Version: 2019-07-24
+
+*/
+
 !addplugindir /x86-ansi ".\..\..\Plugins\x86-ansi"
 !addplugindir /x86-unicode ".\..\..\Plugins\x86-unicode"
 !addincludedir ".\..\..\Include"

--- a/Demos/NSIS_Full/Uninstall.nsh
+++ b/Demos/NSIS_Full/Uninstall.nsh
@@ -1,3 +1,16 @@
+/*
+
+NsisMultiUser.nsh - NSIS plugin that allows "per-user" (no admin required) and "per-machine" (asks elevation *only when necessary*) installations
+
+Full source code, documentation and demos at https://github.com/Drizin/NsisMultiUser/
+
+Copyright 2016-2019 Ricardo Drizin, Alex Mitev
+
+File   : Demos\NSIS_Full\Uninstall.nsh
+Version: 2019-07-24
+
+*/
+
 !include un.Utils.nsh
 
 ; Variables

--- a/Demos/UMUI_Ex_Full/Setup.nsi
+++ b/Demos/UMUI_Ex_Full/Setup.nsi
@@ -1,3 +1,16 @@
+/*
+
+NsisMultiUser.nsh - NSIS plugin that allows "per-user" (no admin required) and "per-machine" (asks elevation *only when necessary*) installations
+
+Full source code, documentation and demos at https://github.com/Drizin/NsisMultiUser/
+
+Copyright 2016-2019 Ricardo Drizin, Alex Mitev
+
+File   : Demos\UMUI_Ex_Full\Setup.nsi
+Version: 2019-07-24
+
+*/
+
 !addplugindir /x86-ansi ".\..\..\Plugins\x86-ansi"
 !addplugindir /x86-unicode ".\..\..\Plugins\x86-unicode"
 !addincludedir ".\..\..\Include"

--- a/Demos/UMUI_Ex_Full/Uninstall.nsh
+++ b/Demos/UMUI_Ex_Full/Uninstall.nsh
@@ -1,3 +1,16 @@
+/*
+
+NsisMultiUser.nsh - NSIS plugin that allows "per-user" (no admin required) and "per-machine" (asks elevation *only when necessary*) installations
+
+Full source code, documentation and demos at https://github.com/Drizin/NsisMultiUser/
+
+Copyright 2016-2019 Ricardo Drizin, Alex Mitev
+
+File   : Demos\UMUI_Ex_Full\Uninstall.nsh
+Version: 2019-07-24
+
+*/
+
 !include un.Utils.nsh
 
 ; Variables

--- a/Include/NsisMultiUser.nsh
+++ b/Include/NsisMultiUser.nsh
@@ -6,6 +6,9 @@ Full source code, documentation and demos at https://github.com/Drizin/NsisMulti
 
 Copyright 2016-2018 Ricardo Drizin, Alex Mitev
 
+File   : Include\NsisMultiUser.nsh
+Version: 2019-07-11
+
 */
 
 !verbose push

--- a/Include/NsisMultiUserLang.nsh
+++ b/Include/NsisMultiUserLang.nsh
@@ -1,3 +1,16 @@
+/*
+
+NsisMultiUser.nsh - NSIS plugin that allows "per-user" (no admin required) and "per-machine" (asks elevation *only when necessary*) installations
+
+Full source code, documentation and demos at https://github.com/Drizin/NsisMultiUser/
+
+Copyright 2016-2018 Ricardo Drizin, Alex Mitev
+
+File   : Include\NsisMultiUserLang.nsh
+Version: 2019-07-11
+
+*/
+
 !ifdef LANG_ENGLISH
 	LangString MULTIUSER_PAGE_TITLE ${LANG_ENGLISH} "Choose Users"
 	LangString MULTIUSER_INSTALL_PAGE_SUBTITLE ${LANG_ENGLISH} "Choose for which users to install $(^NameDA)."


### PR DESCRIPTION
…projects

Added some notes to files lately changed (2019) that downstream projects (projects that use NsisMultiUser) can better manage & handle the versions of NsMultiUser (files).

Changes made:
- Added header with project name copied from Include\NsisMultiUser.nsh
- Copyright year bumped to 2019 in the header
- Added relative path (in the project) & file name to the header
- Added "Version" with last commit of file to the header