### PR TITLE
Add .gitattributes for correct line-breaks by checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,54 @@
+#    BleachBit
+#    Copyright (C) 2008-2019 Andrew Ziem
+#    https://www.bleachbit.org
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#    @file .gitattributes
+#    @repo bleachbit/bleachbit, az0/cleanerml
+#    @version v0.1.0
+#    @date 2019-11-12
+#    @by https://github.com/Tobias-B-Besemer
+#    @note One .gitattributes file for both repos! Make updates easier!
+#    @note This file should help at least by linting!
+
+# Doc is here: https://help.github.com/en/github/using-git/configuring-git-to-handle-line-endings
+
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.c text
+*.h text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.sln text eol=crlf
+*.bat text eol=crlf
+*.nsi text eol=crlf
+*.nsh text eol=crlf
+*.ini text eol=crlf
+
+# Declare files that will always have LF line endings on checkout.
+*.xml text eol=lf
+*.xsd text eol=lf
+*.md text eol=lf
+*.py text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.bmp binary
+*.ico binary
+*.dll binary


### PR DESCRIPTION
I will suggest you to add a file ".gitattributes" for correct line-breaks by checkout to your repo.

We at https://github.com/bleachbit/bleachbit started to use a file ".gitattributes" to have correct line-breaks by checkout no matter if you checkout with Windows (CRLF), or with a Unix-like system (LF).
This helps us e.g. by linting and solves some other issues that came up in the past...
For the beginning I created a simple and basic ".gitattributes" file.
In this file is e.g. defined, that NSI & NSH files from NSIS have ever a CRLF as line-break, because NSIS is a Windows installer and therefor Windows line-breaks make IMHO much sense...
After introducing ".gitattributes" we got in some trouble with NsisMultiUser.nsh and UAC.nsh.
I guess the problems come from because the files have no CRLF... (?)
And so I report now this problem upstream (by you) and want suggest you to use a ".gitattributes" for checkout in future, too.
The basic ".gitattributes" I have created is this PR. You can easily edit and improve it, or just use it as it is...
...if you use I will be really happy and thankful!